### PR TITLE
Keep swing meter visible briefly

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,10 +113,13 @@ function startSwingMeter(scene) {
 function endSwing(scene) {
   swingActive = false;
   cursor.setVisible(false);
-  swingBar.setVisible(false);
-  redZone.setVisible(false);
-  yellowZone.setVisible(false);
-  greenZone.setVisible(false);
+  // Leave the meter visible briefly so players can see the result
+  scene.time.delayedCall(1000, () => {
+    swingBar.setVisible(false);
+    redZone.setVisible(false);
+    yellowZone.setVisible(false);
+    greenZone.setVisible(false);
+  });
 
   const accuracy = Math.abs(cursor.x - redZone.x);
   let payout = 0;


### PR DESCRIPTION
## Summary
- keep the swing meter visible for one second after pressing space

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885f84c54c08330819a8517e8476185