### PR TITLE
Add shop with weapon upgrades and dynamic gold

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,42 @@ let greenZone;
 let swingBar;
 let splatter;
 let executeButton;
-let lastGoldTime = 0;
+let shopButton;
+let shopContainer;
+
+const baseSizes = { red: 60, yellow: 40, green: 20 };
+let zoneMods = { red: 0, yellow: 0, green: 0 };
+
+const weapons = [
+  {
+    name: 'Excalibur',
+    type: 'Sword',
+    cost: 50,
+    desc: 'Legendary blade of kings, widens red zone for precise justice.',
+    effects: { red: 20 }
+  },
+  {
+    name: 'Gungnir',
+    type: 'Spear',
+    cost: 100,
+    desc: "Odin's unstoppable spear expands yellow zone for deadlier punishment strikes.",
+    effects: { red: 10, yellow: 20 }
+  },
+  {
+    name: 'Mjolnir',
+    type: 'Hammer',
+    cost: 200,
+    desc: "Thunder god's hammer broadens green zone to shatter stubborn necks.",
+    effects: { red: 10, yellow: 10, green: 10 }
+  },
+  {
+    name: 'Masamune',
+    type: 'Katana',
+    cost: 400,
+    desc: "Famed smith's katana enlarges all zones ensuring flawless beheadings everytime.",
+    effects: { red: 10, yellow: 10, green: 10 }
+  }
+];
 
 function preload() {
   // Placeholder assets using graphics
@@ -73,13 +108,41 @@ function create() {
 
   // Swing meter base
   swingBar = scene.add.rectangle(400, 350, 300, 20, 0x333333).setVisible(false);
-  redZone = scene.add.rectangle(400, 350, 60, 20, 0xff0000).setVisible(false);
-  yellowZone = scene.add.rectangle(400, 350, 40, 20, 0xffff00).setVisible(false);
-  greenZone = scene.add.rectangle(400, 350, 20, 20, 0x00ff00).setVisible(false);
+  redZone = scene.add.rectangle(400, 350, baseSizes.red, 20, 0xff0000).setVisible(false);
+  yellowZone = scene.add.rectangle(400, 350, baseSizes.yellow, 20, 0xffff00).setVisible(false);
+  greenZone = scene.add.rectangle(400, 350, baseSizes.green, 20, 0x00ff00).setVisible(false);
   cursor = scene.add.rectangle(250, 350, 10, 20, 0xffffff).setVisible(false);
 
   // Splatter placeholder
   splatter = scene.add.rectangle(400, 490, 50, 10, 0x000000).setVisible(false);
+
+  // Shop button
+  shopButton = scene.add.text(700, 560, '[ Shop ]', { font: '20px monospace', fill: '#ffffff' })
+    .setInteractive()
+    .on('pointerdown', () => {
+      toggleShop(scene);
+    });
+
+  // Shop container
+  shopContainer = scene.add.container(100, 100).setVisible(false);
+  const shopBg = scene.add.rectangle(0, 0, 600, 380, 0x000000, 0.9).setOrigin(0, 0);
+  shopBg.setStrokeStyle(2, 0xffffff);
+  shopContainer.add(shopBg);
+  let itemY = 20;
+  weapons.forEach((w, idx) => {
+    const title = scene.add.text(10, itemY, `${w.name} - ${w.type} - ${w.cost}g`, { font: '18px monospace', fill: '#ffffaa' });
+    const desc = scene.add.text(20, itemY + 20, w.desc, { font: '14px monospace', fill: '#ffffff' });
+    const buy = scene.add.text(450, itemY, '[Buy]', { font: '18px monospace', fill: '#00ff00' })
+      .setInteractive()
+      .on('pointerdown', () => { buyWeapon(scene, idx); });
+    shopContainer.add([title, desc, buy]);
+    w.ui = { buy };
+    itemY += 70;
+  });
+  const closeBtn = scene.add.text(560, 10, '[X]', { font: '18px monospace', fill: '#ffffff' })
+    .setInteractive()
+    .on('pointerdown', () => { toggleShop(scene); });
+  shopContainer.add(closeBtn);
 
   // Text popup
   scene.popupText = scene.add.text(300, 250, '', { font: '24px serif', fill: '#ffffff' }).setVisible(false);
@@ -92,6 +155,34 @@ function create() {
 
 let swingDirection = 1;
 
+function toggleShop(scene) {
+  const visible = !shopContainer.visible;
+  shopContainer.setVisible(visible);
+}
+
+function buyWeapon(scene, index) {
+  const w = weapons[index];
+  if (w.purchased) return;
+  if (gold >= w.cost) {
+    gold -= w.cost;
+    goldText.setText(`Gold: ${gold}`);
+    zoneMods.red += w.effects.red || 0;
+    zoneMods.yellow += w.effects.yellow || 0;
+    zoneMods.green += w.effects.green || 0;
+    updateZones();
+    w.purchased = true;
+    if (w.ui && w.ui.buy) {
+      w.ui.buy.setText('Bought').disableInteractive();
+    }
+  }
+}
+
+function updateZones() {
+  redZone.displayWidth = baseSizes.red + zoneMods.red;
+  yellowZone.displayWidth = baseSizes.yellow + zoneMods.yellow;
+  greenZone.displayWidth = baseSizes.green + zoneMods.green;
+}
+
 function startSwingMeter(scene) {
   swingActive = true;
   cursor.setVisible(true);
@@ -101,6 +192,8 @@ function startSwingMeter(scene) {
   greenZone.setVisible(true);
   splatter.setVisible(false);
   scene.popupText.setVisible(false);
+
+  updateZones();
 
   // Reset positions
   cursor.x = 250;
@@ -125,18 +218,18 @@ function endSwing(scene) {
   let payout = 0;
   let message = '';
 
-  if (accuracy < 10) {
+  if (accuracy <= greenZone.displayWidth / 2) {
     payout = 10;
-    message = 'One Cut!';
-  } else if (accuracy < 20) {
+    message = 'Perfect!';
+  } else if (accuracy <= yellowZone.displayWidth / 2) {
     payout = 5;
     message = 'Close!';
-  } else if (accuracy < 30) {
+  } else if (accuracy <= redZone.displayWidth / 2) {
     payout = 2;
     message = 'Messy...';
   } else {
-    payout = 1;
-    message = 'Botched!';
+    payout = -2;
+    message = 'Missed!';
   }
 
   gold += payout;
@@ -151,12 +244,6 @@ function endSwing(scene) {
 }
 
 function update(time, delta) {
-  // Idle gold every 5 seconds
-  if (time - lastGoldTime > 5000) {
-    gold += 1;
-    goldText.setText(`Gold: ${gold}`);
-    lastGoldTime = time;
-  }
 
   // Move cursor
   if (swingActive) {


### PR DESCRIPTION
## Summary
- add weapons data and zone modifiers
- create shop overlay and toggle button
- add buying logic to update zone sizes
- change gold payouts based on zone accuracy and penalize misses
- remove idle gold accumulation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885fc364c6883308437ffb070a210c4