### PR TITLE
Add blood pool and scaled spurts

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ let redZone;
 let yellowZone;
 let greenZone;
 let swingBar;
-let splatter;
+let bloodPool;
 let bloodEmitter;
 let inputEnabled = true;
 let shopButton;
@@ -122,8 +122,10 @@ function create() {
   greenZone = scene.add.rectangle(400, 350, baseSizes.green, 20, 0x00ff00).setVisible(false);
   cursor = scene.add.rectangle(250, 350, 10, 20, 0xffffff).setVisible(false);
 
-  // Splatter placeholder
-  splatter = scene.add.rectangle(400, 490, 50, 10, 0xff0000).setVisible(false);
+  // Blood pool
+  bloodPool = scene.add.rectangle(400, 500, 60, 10, 0x770000)
+    .setOrigin(0.5, 0)
+    .setVisible(false);
 
   // Blood particle emitter
   const g = scene.add.graphics();
@@ -229,7 +231,7 @@ function startSwingMeter(scene) {
   redZone.setVisible(true);
   yellowZone.setVisible(true);
   greenZone.setVisible(true);
-  splatter.setVisible(false);
+  // leave bloodPool visible between swings
   scene.popupText.setVisible(false);
 
   updateZones();
@@ -258,26 +260,32 @@ function endSwing(scene) {
   let payout = 0;
   let message = '';
 
+  let bloodAmount;
   if (accuracy <= greenZone.displayWidth / 2) {
     payout = 10;
     message = 'Perfect!';
+    bloodAmount = 150; // big spurt
   } else if (accuracy <= yellowZone.displayWidth / 2) {
     payout = 5;
     message = 'Close!';
+    bloodAmount = 60;
   } else if (accuracy <= redZone.displayWidth / 2) {
     payout = 2;
     message = 'Messy...';
+    bloodAmount = 20;
   } else {
     payout = -2;
     message = 'Missed!';
+    bloodAmount = 5;
   }
 
   gold += payout;
   goldText.setText(`Gold: ${gold}`);
 
-  // Show splatter
-  splatter.setVisible(true);
-  bloodEmitter.explode(15, 400, 430);
+  // Show blood burst and grow the pool
+  bloodPool.setVisible(true);
+  bloodPool.displayWidth = Math.min(bloodPool.displayWidth + bloodAmount / 3, 300);
+  bloodEmitter.explode(bloodAmount, 400, 430);
 
   // Show popup
   scene.popupText.setText(message);


### PR DESCRIPTION
## Summary
- rename `splatter` to `bloodPool`
- add a persistent blood pool object
- scale blood burst quantity based on hit accuracy, with 10x blood on perfect hits
- leave the pool visible between swings so blood can accumulate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688626a089a88330bc158d0fb20c3b88