### PR TITLE
Fix head detach repeating only first kill

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v37';
+const VERSION = 'v39';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -59,6 +59,7 @@ let shopContainer;
 let shopOverlay;
 let startContainer;
 let hideMeterEvent;
+let headResetEvent;
 let prisoner;
 let prisonerBody;
 let prisonerHead;
@@ -325,6 +326,10 @@ function savePrisoner(scene) {
 }
 
 function beheadPrisoner(scene, bloodAmount) {
+  if (headResetEvent) {
+    headResetEvent.remove(false);
+    headResetEvent = null;
+  }
   const angle = Phaser.Math.Between(-110, -70);
   const rad = Phaser.Math.DegToRad(angle);
 
@@ -344,7 +349,7 @@ function beheadPrisoner(scene, bloodAmount) {
   body.setAllowGravity(true);
   body.setVelocity(Math.cos(rad) * 250, Math.sin(rad) * 250);
   body.setAngularVelocity(Phaser.Math.Between(-200, 200));
-  scene.time.delayedCall(2500, () => {
+  headResetEvent = scene.time.delayedCall(2500, () => {
     body.setVelocity(0, 0);
     body.setAngularVelocity(0);
     body.setAllowGravity(false);
@@ -353,6 +358,7 @@ function beheadPrisoner(scene, bloodAmount) {
     scene.physics.world.disable(prisonerHead);
     prisoner.add(prisonerHead);
     prisonerHead.setPosition(0, -20);
+    headResetEvent = null;
   });
 
   // Continuous spurting from the flying head
@@ -366,6 +372,10 @@ function beheadPrisoner(scene, bloodAmount) {
 }
 
 function spawnPrisoner(scene, fromRight) {
+  if (headResetEvent) {
+    headResetEvent.remove(false);
+    headResetEvent = null;
+  }
   prisonerClass = pickClass();
   prisonerBody.fillColor = prisonerClass.color;
   swingSpeed = prisonerClass.speed;


### PR DESCRIPTION
## Summary
- prevent overlapping timers from resetting the head during beheadings
- bump displayed version

## Testing
- `./scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_68864ce583e0833086c06fd6bfe93fc3