### PR TITLE
Fix aim arrow orientation and remove placeholder text

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v47';
+const VERSION = 'v49';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -136,7 +136,6 @@ function create() {
 
   // Execution platform (placeholder)
   scene.add.rectangle(400, 500, 300, 20, 0x553311);
-  scene.add.text(320, 470, 'Execution Block', { font: '16px serif', fill: '#aaa' });
 
   // Condemned figure with separate head and body
   prisoner = scene.add.container(400, 460);
@@ -145,9 +144,9 @@ function create() {
   const headSquare = scene.add.rectangle(0, 0, 30, 30, 0xdddddd);
   prisonerFace = scene.add.text(0, 0, ':(', { font: '16px monospace', fill: '#000' }).setOrigin(0.5);
   prisonerHead.add([headSquare, prisonerFace]);
-  // Aim arrow now points horizontally so players choose left/right angles
-  aimArrow = scene.add.triangle(0, 0, 0, -6, 0, 6, 20, 0, 0xffff00)
-    .setOrigin(0, 0.5)
+  // Aim arrow points upward for angle selection
+  aimArrow = scene.add.triangle(0, -25, 0, -20, -6, 0, 6, 0, 0xffff00)
+    .setOrigin(0.5, 1)
     .setVisible(false);
   prisonerHead.add(aimArrow);
   prisoner.add([prisonerBody, prisonerHead]);
@@ -394,11 +393,11 @@ function showAimArrow(scene, bloodAmount, nextSide) {
   pendingBlood = bloodAmount;
   pendingSpawnSide = nextSide;
   // Start the arrow pointing left and sweep to the right
-  aimArrow.setAngle(180);
+  aimArrow.setAngle(-90);
   aimArrow.setVisible(true);
   arrowTween = scene.tweens.add({
     targets: aimArrow,
-    angle: { from: 180, to: 0 },
+    angle: { from: -180, to: 0 },
     duration: 800,
     yoyo: true,
     repeat: -1


### PR DESCRIPTION
## Summary
- orient the aim arrow upward again so it sweeps left-to-right
- remove the "Execution Block" text from the background

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688657bb1a448330a80986a6f0532225