### PR TITLE
Fix respawn timing after saved prisoner

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v87';
+const VERSION = 'v89';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -678,7 +678,7 @@ function endSwing(scene) {
     savePrisoner(scene);
     spawnSide = 'left';
     pendingSpawnSide = 'left';
-    spawnDelay = 1000;
+    spawnDelay = 2000; // wait for the freed prisoner to exit right
   }
   message = `Missed!\n${strikeMsg}`;
   killStreak = 0;


### PR DESCRIPTION
## Summary
- ensure new prisoner waits for the previous to exit
- bump version number

## Testing
- `bash scripts/update_version.sh`


------
https://chatgpt.com/codex/tasks/task_e_68869bf434e88330a4d401ef01cb453a