### PR TITLE
Fix corpses jittering after hitting ground

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v120';
+const VERSION = 'v121';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -271,32 +271,25 @@ function create() {
   bodyGroup = scene.physics.add.group();
   // Enable collisions between bodies so they pile up
   scene.physics.add.collider(bodyGroup, bodyGroup);
-  // Soften corpse landing after a couple bounces
+  // Stop corpses completely after two bounces
   scene.physics.world.on('worldbounds', (body, up, down) => {
     const obj = body.gameObject;
     if (!obj || !obj.isCorpse) return;
     if (down) {
       obj.bounceCount = (obj.bounceCount || 0) + 1;
       if (obj.bounceCount >= 2) {
-        // Gradually reduce motion rather than abruptly freezing
-        body.setBounce(0.02);
-        body.setDrag(200, 0);
-        body.setAngularVelocity(body.angularVelocity * 0.5);
         // Lay the corpse on its side most of the time
         if (Math.random() < 0.9) {
           const sign = Math.random() < 0.5 ? -1 : 1;
           obj.setRotation(sign * Phaser.Math.DegToRad(90));
         }
-      }
-      // After hitting the ground start a timer to fully freeze the body
-      if (!obj.freezeTimer) {
-        obj.freezeTimer = scene.time.delayedCall(1000, () => {
-          body.setVelocity(0, 0);
-          body.setAngularVelocity(0);
-          body.setAllowGravity(false);
-          body.setImmovable(true);
-          body.moves = false;
-        });
+
+        body.setBounce(0);
+        body.setVelocity(0, 0);
+        body.setAngularVelocity(0);
+        body.setAllowGravity(false);
+        body.setImmovable(true);
+        body.moves = false;
       }
     }
   });


### PR DESCRIPTION
## Summary
- stop corpses from bouncing and moving after two impacts
- bump version in `index.html`

## Testing
- `scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886bcbd903c8330859e788bb1446762