### PR TITLE
Increase difficulty scaling with kill streak

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v129';
+const VERSION = 'v131';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -788,7 +788,7 @@ function endSwing(scene) {
     missStreak = 0;
     killCount++;
     killStreak++;
-    if (killStreak % 5 === 0) {
+    if (killStreak > 1) {
       speedMultiplier *= 1.05;
     }
     swingSpeed = baseSwingSpeed * speedMultiplier;


### PR DESCRIPTION
## Summary
- tweak speed multiplier so difficulty ramps up as soon as the kill streak multiplier is active
- auto-update version

## Testing
- `./scripts/update_version.sh`


------
https://chatgpt.com/codex/tasks/task_e_688722fa84708330aa5161872b23cb4f