### PR TITLE
Improve NPC size and version format

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v139';
+const VERSION = 'v1.41';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -871,8 +871,8 @@ function spawnFameNpc(scene) {
   const fromRight = Math.random() < 0.5;
   const startX = fromRight ? 850 : -50;
   const speed = 30;
-  const npc = scene.add.container(startX, 500).setDepth(2);
-  const body = scene.add.rectangle(0, 0, 30, 50, 0x888888).setOrigin(0.5, 1);
+  const npc = scene.add.container(startX, 460).setDepth(2);
+  const body = scene.add.rectangle(0, 0, 30, 60, 0x888888).setOrigin(0.5, 1);
   let prop;
   if (Math.random() < 0.5) {
     npc.npcType = 'bucket';

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 # Update VERSION constant in index.html based on git commit count
 count=$(git rev-list --count HEAD)
-# Format version as v<count>
-sed -i -E "s/const VERSION = 'v[0-9.]+';/const VERSION = 'v$count';/" index.html
+major=$((count / 100))
+minor=$((count % 100))
+version="v${major}.${minor}"
+sed -i -E "s/const VERSION = 'v[0-9.]+';/const VERSION = '$version';/" index.html


### PR DESCRIPTION
## Summary
- tweak fame NPC size and spawn height
- change version updater to produce `v<major>.<minor>` format
- bump version

## Testing
- `bash scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_688735b17a248330a70a7d24c4148130