### PR TITLE
Spawn fame NPC alongside prisoner

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v1.47';
+const VERSION = 'v1.50';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -375,7 +375,8 @@ function create() {
     }
   });
 
-  scheduleFameSpawn(scene);
+  // Fame NPCs now spawn together with each prisoner
+  // scheduleFameSpawn(scene); // disabled
 }
 
 let swingDirection = 1;
@@ -629,8 +630,6 @@ function introExecutioner(scene, onComplete) {
 
 function spawnPrisoner(scene, fromRight) {
   prisoner.setVisible(true);
-  // Spawn a fame NPC each time a prisoner arrives for testing
-  spawnFameNpc(scene);
   if (headResetEvent) {
     headResetEvent.remove(false);
     headEmitter.stop();
@@ -644,6 +643,8 @@ function spawnPrisoner(scene, fromRight) {
   bloodEmitter.stop();
   bloodEmitter.stopFollow();
   prisonerClass = pickClass();
+  // Spawn the fame NPC to match this prisoner
+  spawnFameNpc(scene, fromRight, prisonerClass.color);
   prisonerBody.fillColor = prisonerClass.color;
   baseSwingSpeed = prisonerClass.speed;
   swingSpeed = baseSwingSpeed * speedMultiplier;
@@ -869,24 +870,18 @@ function gainFame(scene, npc) {
   npc.destroy();
 }
 
-function spawnFameNpc(scene) {
-  const fromRight = Math.random() < 0.5;
+function spawnFameNpc(scene, fromRight, color) {
   const startX = fromRight ? 850 : -50;
   const speed = 30;
-  // Place the fame NPC on a very high depth so it is always visible
+  // Create a container identical to a prisoner so it's easy to see
   const npc = scene.add.container(startX, 460).setDepth(20);
-  // Use a bright red body color so the NPC stands out clearly
-  const body = scene.add.rectangle(0, 0, 30, 60, 0xff0000).setOrigin(0.5, 1);
-  let prop;
-  if (Math.random() < 0.5) {
-    npc.npcType = 'bucket';
-    prop = scene.add.rectangle(0, -60, 20, 20, 0x4444ff);
-  } else {
-    npc.npcType = 'target';
-    const offset = fromRight ? -30 : 30;
-    prop = scene.add.rectangle(offset, -30, 20, 20, 0xff4444);
-  }
-  npc.add([body, prop]);
+  const body = scene.add.rectangle(0, 50, 30, 60, color).setOrigin(0.5, 1);
+  const head = scene.add.container(0, -20);
+  const headSquare = scene.add.rectangle(0, 0, 30, 30, 0xdddddd);
+  const face = scene.add.text(0, 0, ':(', { font: '16px monospace', fill: '#000' })
+    .setOrigin(0.5);
+  head.add([headSquare, face]);
+  npc.add([body, head]);
   scene.physics.world.enable(npc);
   npc.body.setAllowGravity(false);
   npc.body.setVelocityX(fromRight ? -speed : speed);
@@ -899,7 +894,8 @@ function scheduleFameSpawn(scene) {
   const delay = 100;
   scene.time.delayedCall(delay, () => {
     if (!startContainer.visible) {
-      spawnFameNpc(scene);
+      const fromRight = Math.random() < 0.5;
+      spawnFameNpc(scene, fromRight, 0xaaaaaa);
     }
     scheduleFameSpawn(scene);
   });


### PR DESCRIPTION
## Summary
- disable automatic NPC spawn timer
- spawn a fame NPC from the same side as the prisoner when a prisoner spawns
- give NPC same graphics as prisoner
- bump version

## Testing
- `bash scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_688742e0fc448330a00b5cfa8fbbbdce