### PR TITLE
Fix NPC spawn side

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v1.50';
+const VERSION = 'v1.51';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -643,8 +643,8 @@ function spawnPrisoner(scene, fromRight) {
   bloodEmitter.stop();
   bloodEmitter.stopFollow();
   prisonerClass = pickClass();
-  // Spawn the fame NPC to match this prisoner
-  spawnFameNpc(scene, fromRight, prisonerClass.color);
+  // Spawn the fame NPC from the right side to avoid overlap
+  spawnFameNpc(scene, true, prisonerClass.color);
   prisonerBody.fillColor = prisonerClass.color;
   baseSwingSpeed = prisonerClass.speed;
   swingSpeed = baseSwingSpeed * speedMultiplier;
@@ -871,7 +871,9 @@ function gainFame(scene, npc) {
 }
 
 function spawnFameNpc(scene, fromRight, color) {
-  const startX = fromRight ? 850 : -50;
+  // Start further off-screen when spawning from the right so we don't
+  // collide with a prisoner entering from that side
+  const startX = fromRight ? 900 : -50;
   const speed = 30;
   // Create a container identical to a prisoner so it's easy to see
   const npc = scene.add.container(startX, 460).setDepth(20);


### PR DESCRIPTION
## Summary
- spawn the fame NPC from the right so it no longer overlaps the prisoner
- offset right-side spawn position to prevent immediate collision
- update version

## Testing
- `bash scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_68874713f77c83309364230475904fa9