### PR TITLE
Add swinging logo menu and version script fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v1.59';
+const VERSION = 'v1.60';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -63,6 +63,7 @@ let shopButton;
 let shopContainer;
 let shopOverlay;
 let startContainer;
+let logoContainer;
 let hideMeterEvent;
 let headResetEvent;
 let neckPumpEvent;
@@ -143,7 +144,7 @@ function pickClass() {
 }
 
 function preload() {
-  // Placeholder assets using graphics
+  this.load.image('logo', 'logo.png');
 }
 
 function create() {
@@ -210,6 +211,30 @@ function create() {
     .setOrigin(1, 1)
     .setDepth(11);
 
+  // Logo drop animation before showing the start screen
+  logoContainer = scene.add.container(500, -200).setDepth(10);
+  const rope = scene.add.line(0, 0, 0, 0, 0, 125, 0xffffff).setOrigin(0);
+  const logo = scene.add.image(0, 125, 'logo')
+    .setOrigin(500 / 1024, 125 / 1024)
+    .setScale(0.5);
+  logoContainer.add([rope, logo]);
+  scene.tweens.add({
+    targets: logoContainer,
+    y: 0,
+    ease: 'Bounce',
+    duration: 400,
+    onComplete: () => {
+      scene.tweens.add({
+        targets: logoContainer,
+        angle: { from: -15, to: 15 },
+        duration: 300,
+        ease: 'Sine.easeInOut',
+        yoyo: true,
+        repeat: 3
+      });
+    }
+  });
+
   // Start screen
   startContainer = scene.add.container(0, 0).setDepth(10);
   const startBg = scene.add.rectangle(400, 300, 800, 600, 0x000000, 0.7).setDepth(10);
@@ -226,6 +251,12 @@ function create() {
       }
     });
   startContainer.add([startBg, startText]);
+  startContainer.setVisible(false);
+
+  scene.time.delayedCall(2000, () => {
+    logoContainer.setVisible(false);
+    startContainer.setVisible(true);
+  });
 
   // Swing meter base
   const meterY = 550;

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
-# Update VERSION constant in index.html based on git commit count
-count=$(git rev-list --count HEAD)
-major=$((count / 100))
-minor=$((count % 100))
+# Update VERSION constant in index.html by incrementing the existing value.
+# This avoids issues where commit counts might decrease due to rebases or
+# branch changes and guarantees the version number only increases.
+
+current=$(grep -o "const VERSION = 'v[0-9]*\.[0-9]*';" index.html | grep -o "v[0-9]*\.[0-9]*")
+current=${current#v}
+major=${current%%.*}
+minor=${current##*.}
+minor=$((minor + 1))
+if [ "$minor" -ge 100 ]; then
+  minor=0
+  major=$((major + 1))
+fi
 version="v${major}.${minor}"
 sed -i -E "s/const VERSION = 'v[0-9.]+';/const VERSION = '$version';/" index.html


### PR DESCRIPTION
## Summary
- animate a logo dropping in on a rope before showing the start screen
- hide the start screen until the intro animation completes
- increment the version number reliably on each commit

## Testing
- `bash scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887594fe1f08330801ee2e69ada62fa