### PR TITLE
Fix start prompt layering and rope width

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v1.62';
+const VERSION = 'v1.63';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -215,7 +215,8 @@ function create() {
 
   // Logo drop animation before showing the start screen
   logoContainer = scene.add.container(400, -200).setDepth(11);
-  const rope = scene.add.line(0, 0, 0, 0, 0, 125, 0xffffff).setOrigin(0);
+  const rope = scene.add.rectangle(0, 0, 6, 125, 0xffffff)
+    .setOrigin(0.5, 0);
   const logo = scene.add.image(0, 125, 'logo')
     .setOrigin(500 / 1024, 125 / 1024)
     .setScale(0.5);
@@ -238,7 +239,7 @@ function create() {
   });
 
   // Start screen
-  startContainer = scene.add.container(0, 0).setDepth(10);
+  startContainer = scene.add.container(0, 0).setDepth(12);
   const startBg = scene.add.rectangle(400, 300, 800, 600, 0x000000, 1).setDepth(10);
   const startText = scene.add.text(400, 520, '[ CLICK TO PLAY ]', { font: '32px monospace', fill: '#ffffff' })
     .setOrigin(0.5)


### PR DESCRIPTION
## Summary
- bump version to trigger static site update
- make the rope for the intro logo thicker
- raise start screen container depth so the Click to Play message stays in front

## Testing
- `scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_688763237fc08330993c3a400a648291