### PR TITLE
Update logo rope alignment and start text

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v1.65';
+const VERSION = 'v1.66';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -216,10 +216,10 @@ function create() {
   // Logo drop animation before showing the start screen
   // Ensure the logo appears above the start screen background
   logoContainer = scene.add.container(400, -200).setDepth(13);
-  const rope = scene.add.rectangle(0, 0, 6, 125, 0xffffff)
+  const rope = scene.add.rectangle(0, 0, 12, 125, 0xffffff)
     .setOrigin(0.5, 0);
   const logo = scene.add.image(0, 125, 'logo')
-    .setOrigin(500 / 1024, 125 / 1024)
+    .setOrigin(513 / 1024, 127 / 1024)
     .setScale(0.5);
   logoContainer.add([rope, logo]);
   scene.tweens.add({
@@ -242,7 +242,7 @@ function create() {
   // Start screen
   startContainer = scene.add.container(0, 0).setDepth(12);
   const startBg = scene.add.rectangle(400, 300, 800, 600, 0x000000, 1).setDepth(10);
-  const startText = scene.add.text(400, 540, '[ CLICK TO PLAY ]', { font: '32px monospace', fill: '#ffffff' })
+  const startText = scene.add.text(400, 560, '[ CLICK TO PLAY ]', { font: '32px monospace', fill: '#ffffff' })
     .setOrigin(0.5)
     .setInteractive()
     .setDepth(10)


### PR DESCRIPTION
## Summary
- drop the 'Click to Play' prompt 20px lower
- widen the drop rope to align better with the logo
- adjust logo rope origin to match new hole location
- bump game version

## Testing
- `./scripts/update_version.sh`


------
https://chatgpt.com/codex/tasks/task_e_688774efc7148330aef871fe9948859f