### PR TITLE
Use platform image for execution stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v1.72';
+const VERSION = 'v1.74';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -148,6 +148,7 @@ function pickClass() {
 function preload() {
   this.load.image('logo', 'logo.png');
   this.load.image('shop', 'shop.png');
+  this.load.image('platform', 'platform.png');
 }
 
 function create() {
@@ -156,8 +157,8 @@ function create() {
   // Background
   scene.add.rectangle(400, 300, 800, 600, 0x2d2d2d);
 
-  // Execution platform (placeholder)
-  scene.add.rectangle(400, 500, 300, 20, 0x553311);
+  // Execution platform
+  scene.add.image(400, 500, 'platform');
 
   // Executioner, starts off-screen and walks in on first spawn
   // Place him behind the prisoner but in front of the background


### PR DESCRIPTION
## Summary
- load `platform.png` during preload
- show the image instead of a placeholder rectangle
- bump version

## Testing
- `./scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_688799d873ac83309a09472201b86b88