### PR TITLE
Fix overlay depth and jester model

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ let dripEmitter;
 let headEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v1.92';
+const VERSION = 'v1.93';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -290,6 +290,8 @@ function preload() {
   this.load.image('background', 'background.png');
   this.load.image('prisonerHeadImg', 'prisonerhead.png');
   this.load.image('prisonerBodyImg', 'prisonerbody.png');
+  this.load.image('jesterHeadImg', 'jesterhead.png');
+  this.load.image('jesterBodyImg', 'jesterbody.png');
 }
 
 function create() {
@@ -298,11 +300,12 @@ function create() {
   // Background and stage art
   backgroundRect = scene.add.image(400, 300, 'background');
   backgroundRect.setDisplaySize(800, 600);
-  stage = scene.add.image(400, 520, 'platform');
+  backgroundRect.setDepth(-2);
+  stage = scene.add.image(400, 520, 'platform').setDepth(0);
 
   backOverlay = scene.add.rectangle(400, 300, 800, 600, 0x000000)
     .setAlpha(0)
-    .setDepth(0.4)
+    .setDepth(-1)
     .setVisible(false);
 
   // Executioner, starts off-screen and walks in on first spawn
@@ -512,6 +515,17 @@ function create() {
     const obj = body.gameObject;
     if (!obj || !obj.isCorpse) return;
     if (down) {
+      if (obj.jester && !obj.jester.running) {
+        obj.jester.running = true;
+        const offX = obj.jester.startFromRight ? 900 : -100;
+        obj.scene.tweens.add({
+          targets: obj.jester,
+          x: offX,
+          duration: 1500,
+          ease: 'Linear',
+          onComplete: () => obj.jester.destroy()
+        });
+      }
       obj.bounceCount = (obj.bounceCount || 0) + 1;
       if (obj.bounceCount >= 2) {
         // Lay the corpse on its side most of the time
@@ -987,34 +1001,28 @@ function beheadPrisoner(scene, bloodAmount, angleDeg, power = 1) {
   bloodPool.setVisible(true);
   bloodPool.displayWidth = Math.min(bloodPool.displayWidth + 5, 300);
 
-  // Detach head from prisoner container so it can fly freely
-  if (prisonerHead.parentContainer === prisoner) {
-    const worldX = prisoner.x + prisonerHead.x;
-    const worldY = prisoner.y + prisonerHead.y;
-    prisoner.remove(prisonerHead);
-    prisonerHead.setPosition(worldX, worldY);
-    scene.add.existing(prisonerHead);
-    prisonerHead.setDepth(1);
-  }
   // Hide the template prisoner while the physics body takes over
   prisoner.setVisible(false);
 
-  // Always re-enable physics on the head so it can fly each time
-  scene.physics.world.enable(prisonerHead);
-  const body = prisonerHead.body;
-  body.setAllowGravity(true);
+  // Spawn a new flying head sprite
+  const flyingHead = scene.add.image(headX0, headY0, 'prisonerHeadImg')
+    .setOrigin(0.5)
+    .setDepth(1);
+  scene.physics.world.enable(flyingHead);
+  bodyGroup.add(flyingHead);
+  flyingHead.isCorpse = true;
+  flyingHead.bounceCount = 0;
+  const hBody = flyingHead.body;
+  hBody.setAllowGravity(true);
+  hBody.onWorldBounds = true;
+  hBody.setCollideWorldBounds(true);
+  hBody.setBounce(0.05);
+  hBody.setDrag(50, 0);
   const speed = 250 * power;
-  body.setVelocity(Math.sin(rad) * speed, -Math.cos(rad) * speed);
-  body.setAngularVelocity(Phaser.Math.Between(-200, 200));
+  hBody.setVelocity(Math.sin(rad) * speed, -Math.cos(rad) * speed);
+  hBody.setAngularVelocity(Phaser.Math.Between(-200, 200));
+
   headResetEvent = scene.time.delayedCall(2500, () => {
-    body.setVelocity(0, 0);
-    body.setAngularVelocity(0);
-    body.setAllowGravity(false);
-    prisonerHead.setRotation(0);
-    prisonerHead.setPosition(prisoner.x, prisoner.y - 20);
-    scene.physics.world.disable(prisonerHead);
-    prisoner.add(prisonerHead);
-    prisonerHead.setPosition(0, -20);
     headEmitter.stop();
     headEmitter.stopFollow();
     bloodEmitter.stop();
@@ -1027,7 +1035,7 @@ function beheadPrisoner(scene, bloodAmount, angleDeg, power = 1) {
   });
 
   // Continuous spurting from the flying head
-  headEmitter.startFollow(prisonerHead, 0, 15);
+  headEmitter.startFollow(flyingHead, 0, 15);
   headEmitter.setFrequency(20);
   headEmitter.setQuantity(Math.max(5, bloodAmount / 30));
   headEmitter.start();
@@ -1110,7 +1118,7 @@ function introExecutioner(scene, onComplete) {
   scene.tweens.add({
     targets: backOverlay,
     alpha: 0.5,
-    duration: 2000,
+    duration: 800,
     ease: 'Linear'
   });
   scene.tweens.add({
@@ -1163,7 +1171,7 @@ function spawnPrisoner(scene, fromRight) {
     scene.tweens.add({
       targets: backOverlay,
       alpha: 0.5,
-      duration: 2000,
+      duration: 800,
       ease: 'Linear'
     });
   }
@@ -1374,16 +1382,7 @@ function gainFame(scene, npc) {
     duration: 800,
     onComplete: () => popup.destroy()
   });
-  if (npc.jester) {
-    const offX = npc.jester.startFromRight ? 900 : -100;
-    scene.tweens.add({
-      targets: npc.jester,
-      x: offX,
-      duration: 1500,
-      ease: 'Linear',
-      onComplete: () => npc.jester.destroy()
-    });
-  }
+  // Jester will run off when the target hits the ground
 }
 
 function spawnTarget(scene) {
@@ -1394,10 +1393,10 @@ function spawnTarget(scene) {
 
   const jester = scene.add.container(startX, 460).setDepth(1);
   jester.startFromRight = fromRight;
-  const body = scene.add.image(0, 50, 'prisonerBodyImg').setOrigin(0.5, 1);
+  const body = scene.add.image(0, 50, 'jesterBodyImg').setOrigin(0.5, 1);
   const pole = scene.add.rectangle(0, -20, 6, poleHeight, 0x8b4513)
     .setOrigin(0.5, 1);
-  const head = scene.add.image(0, -20, 'prisonerHeadImg').setOrigin(0.5);
+  const head = scene.add.image(0, -20, 'jesterHeadImg').setOrigin(0.5);
   jester.add([body, pole, head]);
 
   const target = scene.add.container(0, -20 - poleHeight).setDepth(20);


### PR DESCRIPTION
## Summary
- load new jester art
- adjust background darkening overlay depth
- speed up overlay fade
- spawn jester using new graphics
- run jester off after target falls
- leave severed heads on the ground
- bump game version

## Testing
- `bash scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888ddbb09308330a4afa895eb634109