### PR TITLE
Improve trading market UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ let headEmitter;
 let splatEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v1.99';
+const VERSION = 'v2.0';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -240,8 +240,8 @@ function updateMarketChatter() {
       const color = Phaser.Utils.Array.GetRandom(classes).color;
       marketPrisoner.list[0].setTint(color);
       const txt = marketChatterText;
-      marketPrisoner.x = txt.x + txt.width + 10;
-      marketPrisoner.y = txt.y + txt.height;
+      marketPrisoner.x = txt.x + txt.width / 2 + 10;
+      marketPrisoner.y = txt.y + txt.height / 2;
     }
   }
 }
@@ -668,33 +668,53 @@ function create() {
     itemY += 70;
   });
 
-  // Market items
+  // Market items displayed as a table
   itemY = 0;
+  const cols = {
+    name: 10,
+    buy: 210,
+    sell: 270,
+    qty: 330,
+    buyBtn: 390,
+    buy10Btn: 450,
+    sellBtn: 520,
+    sell10Btn: 590
+  };
+  // Header row
+  scene.add.text(cols.name, itemY, 'Item', { font: '18px monospace', fill: '#ffffaa' });
+  scene.add.text(cols.buy, itemY, 'Buy', { font: '18px monospace', fill: '#ffffaa' });
+  scene.add.text(cols.sell, itemY, 'Sell', { font: '18px monospace', fill: '#ffffaa' });
+  scene.add.text(cols.qty, itemY, 'Qty', { font: '18px monospace', fill: '#ffffaa' });
+  itemY += 25;
+
   marketItems.forEach((m, idx) => {
-    const line = scene.add.text(10, itemY, '', { font: '18px monospace', fill: '#ffffaa' });
-    const buyBtn = scene.add.text(520, itemY, '[Buy]', { font: '18px monospace', fill: '#00ff00' })
+    const name = scene.add.text(cols.name, itemY, m.name, { font: '18px monospace', fill: '#ffffaa' });
+    const buyPrice = scene.add.text(cols.buy, itemY, '', { font: '18px monospace', fill: '#ffffaa' });
+    const sellPrice = scene.add.text(cols.sell, itemY, '', { font: '18px monospace', fill: '#ffffaa' });
+    const qtyText = scene.add.text(cols.qty, itemY, '', { font: '18px monospace', fill: '#ffffaa' });
+    const buyBtn = scene.add.text(cols.buyBtn, itemY, '[Buy]', { font: '18px monospace', fill: '#00ff00' })
       .setInteractive()
       .on('pointerdown', () => { buyMarketItem(scene, idx, 1); });
-    const buy10Btn = scene.add.text(570, itemY, '[Buy10]', { font: '18px monospace', fill: '#00ff00' })
+    const buy10Btn = scene.add.text(cols.buy10Btn, itemY, '[Buy10]', { font: '18px monospace', fill: '#00ff00' })
       .setInteractive()
       .on('pointerdown', () => { buyMarketItem(scene, idx, 10); });
-    const sellBtn = scene.add.text(640, itemY, '[Sell]', { font: '18px monospace', fill: '#00ff00' })
+    const sellBtn = scene.add.text(cols.sellBtn, itemY, '[Sell]', { font: '18px monospace', fill: '#00ff00' })
       .setInteractive()
       .on('pointerdown', () => { sellMarketItem(scene, idx, 1); });
-    const sell10Btn = scene.add.text(700, itemY, '[Sell10]', { font: '18px monospace', fill: '#00ff00' })
+    const sell10Btn = scene.add.text(cols.sell10Btn, itemY, '[Sell10]', { font: '18px monospace', fill: '#00ff00' })
       .setInteractive()
       .on('pointerdown', () => { sellMarketItem(scene, idx, 10); });
-    marketList.add([line, buyBtn, buy10Btn, sellBtn, sell10Btn]);
-    m.ui = { line, buyBtn, buy10Btn, sellBtn, sell10Btn };
-    itemY += 30;
+    marketList.add([name, buyPrice, sellPrice, qtyText, buyBtn, buy10Btn, sellBtn, sell10Btn]);
+    m.ui = { name, buyPrice, sellPrice, qtyText, buyBtn, buy10Btn, sellBtn, sell10Btn };
+    itemY += 25;
   });
-  marketChatterText = scene.add.text(10, itemY + 40, '', {
-    font: '16px monospace',
+  marketChatterText = scene.add.text(350, 440, '', {
+    font: '20px monospace',
     fill: '#ffaaaa',
-    wordWrap: { width: 680 }
-  });
-  const body = scene.add.image(0, 0, 'prisonerBodyImg').setOrigin(0.5, 1).setScale(0.5);
-  const head = scene.add.image(0, -40, 'prisonerHeadImg').setOrigin(0.5).setScale(0.5);
+    wordWrap: { width: 640 }
+  }).setOrigin(0.5);
+  const body = scene.add.image(0, 0, 'prisonerBodyImg').setOrigin(0.5, 1).setScale(1);
+  const head = scene.add.image(0, -80, 'prisonerHeadImg').setOrigin(0.5).setScale(1);
   marketPrisoner = scene.add.container(0, 0, [body, head]);
   marketList.add([marketChatterText, marketPrisoner]);
 
@@ -849,26 +869,18 @@ function updateMarketUI() {
     if (!m.ui) return;
     const qty = inventory[m.name] || 0;
     const locked = fame < m.fameReq;
-    const text = locked
-      ? `${m.name} - Locked (Fame ${m.fameReq})`
-      : `${m.name} - Buy:${m.currentBuy}g Sell:${m.currentSell}g Qty:${qty}`;
-    m.ui.line.setText(text);
-    if (m.ui.buyBtn) {
-      const canBuy = !locked && gold >= m.currentBuy;
-      m.ui.buyBtn.setFill(canBuy ? '#00ff00' : '#777777');
-    }
-    if (m.ui.buy10Btn) {
-      const canBuy10 = !locked && gold >= m.currentBuy * 10;
-      m.ui.buy10Btn.setFill(canBuy10 ? '#00ff00' : '#777777');
-    }
-    if (m.ui.sellBtn) {
-      const canSell = qty >= 1;
-      m.ui.sellBtn.setFill(canSell ? '#00ff00' : '#777777');
-    }
-    if (m.ui.sell10Btn) {
-      const canSell10 = qty >= 10;
-      m.ui.sell10Btn.setFill(canSell10 ? '#00ff00' : '#777777');
-    }
+    m.ui.name.setText(locked ? `${m.name} (F${m.fameReq})` : m.name);
+    m.ui.buyPrice.setText(locked ? '-' : `${m.currentBuy}g`);
+    m.ui.sellPrice.setText(locked ? '-' : `${m.currentSell}g`);
+    m.ui.qtyText.setText(qty);
+    const canBuy = !locked && gold >= m.currentBuy;
+    const canBuy10 = !locked && gold >= m.currentBuy * 10;
+    const canSell = qty >= 1;
+    const canSell10 = qty >= 10;
+    m.ui.buyBtn.setFill(canBuy ? '#00ff00' : '#777777');
+    m.ui.buy10Btn.setFill(canBuy10 ? '#00ff00' : '#777777');
+    m.ui.sellBtn.setFill(canSell ? '#00ff00' : '#777777');
+    m.ui.sell10Btn.setFill(canSell10 ? '#00ff00' : '#777777');
   });
 }
 


### PR DESCRIPTION
## Summary
- display the trading market items in a table
- move and enlarge market chatter and prisoner graphic
- double the prisoner size
- bump version number via pre-commit hook

## Testing
- `bash scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_68890683e46883308598414ef124424d