### PR TITLE
Avoid jester spawn when traveling

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ let headEmitter;
 let splatEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v2.0';
+const VERSION = 'v2.1';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -937,7 +937,7 @@ function resetForNewCity(scene) {
   prisoner.setVisible(false);
   leftEscort.setVisible(false);
   rightEscort.setVisible(false);
-  introExecutioner(scene, () => spawnPrisoner(scene, false));
+  introExecutioner(scene, () => spawnPrisoner(scene, false, false));
 }
 
 function selectCity(scene, city) {
@@ -1200,7 +1200,7 @@ function resetHead(scene) {
 
 
 
-function spawnPrisoner(scene, fromRight) {
+function spawnPrisoner(scene, fromRight, withTarget = true) {
   const city = cities.find(c => c.name === currentCity);
   if (city) backgroundRect.setTint(city.bgColor);
   if (backOverlay.alpha === 0) {
@@ -1216,8 +1216,10 @@ function spawnPrisoner(scene, fromRight) {
   prisoner.setVisible(true);
   resetHead(scene);
   prisonerClass = pickClass();
-  // Spawn a new target each time a prisoner appears
-  spawnTarget(scene);
+  // Spawn a new target each time a prisoner appears if requested
+  if (withTarget) {
+    spawnTarget(scene);
+  }
   prisonerBody.setTint(prisonerClass.color);
   baseSwingSpeed = prisonerClass.speed;
   swingSpeed = baseSwingSpeed * speedMultiplier;


### PR DESCRIPTION
## Summary
- allow `spawnPrisoner` to optionally skip creating a jester
- skip spawning a jester when moving to a new city
- bump version to v2.1

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688907cf7c6c8330864dc41f391085f9