### PR TITLE
Increase overlay darkness when executioner arrives

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ let headEmitter;
 let splatEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v2.10';
+const VERSION = 'v2.11';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -1220,7 +1220,7 @@ function introExecutioner(scene, onComplete) {
   backOverlay.setVisible(true);
   scene.tweens.add({
     targets: backOverlay,
-    alpha: 0.5,
+    alpha: 0.6,
     duration: 1000,
     ease: 'Linear'
   });
@@ -1275,7 +1275,7 @@ function spawnPrisoner(scene, fromRight, withTarget = true) {
     backOverlay.setVisible(true);
     scene.tweens.add({
       targets: backOverlay,
-      alpha: 0.5,
+      alpha: 0.6,
       duration: 1000,
       ease: 'Linear'
     });


### PR DESCRIPTION
## Summary
- bump version
- darken background overlay when the executioner walks in
- darken overlay when a new prisoner spawns

## Testing
- `bash scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_68892f301180833093f7184d6e0d8565