### PR TITLE
Fix lingering overlay when switching cities

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ let headEmitter;
 let splatEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v2.17';
+const VERSION = 'v2.18';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -1018,8 +1018,12 @@ function selectCity(scene, city) {
   // Hide the travel UI immediately so its overlay doesn't stack with
   // the background dim when transitioning cities.
   toggleTravel(scene, false);
+  // Force-close the travel menu in case it somehow remained visible.
+  travelOverlay.setVisible(false);
+  travelContainer.setVisible(false);
   // Reset the darkness overlay to match a fresh start.
   backOverlay.setAlpha(0);
+  backOverlay.setVisible(false);
   scene.cameras.main.fadeOut(250, 0, 0, 0);
   scene.time.delayedCall(250, () => {
     scene.cameras.main.once('camerafadeincomplete', () => {


### PR DESCRIPTION
## Summary
- fully hide travel UI before fading when selecting a city
- bump version

## Testing
- `./scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_688936ec47f48330a908f7b629b7e695