### PR TITLE
Disable executioner background fade

### DIFF
--- a/index.html
+++ b/index.html
@@ -1250,12 +1250,12 @@ function introExecutioner(scene, onComplete) {
   executioner.setVisible(true);
   backOverlay.setAlpha(0);
   backOverlay.setVisible(true);
-  scene.tweens.add({
-    targets: backOverlay,
-    alpha: 0.72,
-    duration: 1000,
-    ease: 'Linear'
-  });
+  // scene.tweens.add({
+  //   targets: backOverlay,
+  //   alpha: 0.72,
+  //   duration: 1000,
+  //   ease: 'Linear'
+  // });
   scene.tweens.add({
     targets: executioner,
     x: 400,


### PR DESCRIPTION
## Summary
- comment out the tween that fades in the background overlay when the executioner appears

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6889cf3a000883309d9d7c484140f567