### PR TITLE
Fix travel overlay visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ let headEmitter;
 let splatEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v2.22';
+const VERSION = 'v2.23';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -1040,13 +1040,17 @@ function selectCity(scene, city) {
   // Hide the travel UI immediately so its overlay doesn't stack with
   // the background dim when transitioning cities.
   toggleTravel(scene, false);
-  // Force-close the travel menu in case it somehow remained visible.
+  // Force-close the travel menu in case it somehow remained visible
+  // and ensure the dimming overlay disappears when travelling.
   travelOverlay.setVisible(false);
   travelContainer.setVisible(false);
   // Reset the darkness overlay and begin the new city's intro fresh.
   resetBackOverlay(scene);
   // Directly reset for the new city without fading the camera first.
   resetForNewCity(scene);
+  // Extra safety: hide the travel overlay again in case any async events
+  // re-enabled it during the city transition.
+  travelOverlay.setVisible(false);
 }
 
 function savePrisoner(scene) {


### PR DESCRIPTION
## Summary
- ensure the travel overlay always hides when traveling to a new city
- bump version to v2.23

## Testing
- `scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a03dfa5808330bd816e7bcb2f1840