### PR TITLE
Fix travel fade timing and add background dim overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ let headEmitter;
 let splatEmitter;
 let missText;
 let missStreak = 0;
-const VERSION = 'v2.29';
+const VERSION = 'v2.30';
 let versionText;
 let inputEnabled = true;
 let killCount = 0;
@@ -70,9 +70,10 @@ let speedMultiplier = 1;
 let shopButton;
 let shopContainer;
 let shopOverlay;
-// Global overlay that darkens the game when menus are open or during
-// transitions. We'll fade this in/out at specific moments.
-let backgroundWindowFade;
+// Global overlays for fading: screenFadeOverlay dims the whole screen
+// while backgroundFadeOverlay only darkens the backdrop.
+let screenFadeOverlay;
+let backgroundFadeOverlay;
 let tradeOverlay;
 let tradeContainer;
 let tradeTitle;
@@ -320,10 +321,14 @@ function create() {
   backgroundRect.setDisplaySize(800, 600);
   backgroundRect.setDepth(-2);
   stage = scene.add.image(400, 520, 'platform').setDepth(0);
+  // Overlay that only dims the background behind characters
+  backgroundFadeOverlay = scene.add.rectangle(400, 300, 800, 600, 0x000000, 1)
+    .setDepth(-1)
+    .setAlpha(0)
+    .setVisible(false);
 
-  // Overlay used for fading the entire scene. This stays hidden until
-  // a menu opens or we perform a transition.
-  backgroundWindowFade = scene.add.rectangle(400, 300, 800, 600, 0x000000, 1)
+  // Overlay used for fading the entire screen during menus and transitions.
+  screenFadeOverlay = scene.add.rectangle(400, 300, 800, 600, 0x000000, 1)
     .setDepth(29)
     .setAlpha(0)
     .setVisible(false);
@@ -820,22 +825,43 @@ function create() {
 
 let swingDirection = 1;
 
-// Helper to fade our background window overlay in or out. This drives the
-// dimming effects requested for menus and transitions.
-let bgFadeTween = null;
-function fadeBackgroundWindow(scene, alpha, duration = 300, onComplete) {
-  if (bgFadeTween) {
-    bgFadeTween.stop();
+// Helper to fade the overlay that darkens the entire screen.
+// Used for menu and travel fades.
+let screenFadeTween = null;
+function fadeScreenOverlay(scene, alpha, duration = 300, onComplete) {
+  if (screenFadeTween) {
+    screenFadeTween.stop();
   }
-  backgroundWindowFade.setVisible(true);
-  bgFadeTween = scene.tweens.add({
-    targets: backgroundWindowFade,
+  screenFadeOverlay.setVisible(true);
+  screenFadeTween = scene.tweens.add({
+    targets: screenFadeOverlay,
     alpha,
     duration,
     onComplete: () => {
-      bgFadeTween = null;
+      screenFadeTween = null;
       if (alpha === 0) {
-        backgroundWindowFade.setVisible(false);
+        screenFadeOverlay.setVisible(false);
+      }
+      if (onComplete) onComplete();
+    }
+  });
+}
+
+// Fade only the background layer for dramatic effects, e.g. executioner intro.
+let backgroundFadeTween = null;
+function fadeBackgroundOverlay(scene, alpha, duration = 300, onComplete) {
+  if (backgroundFadeTween) {
+    backgroundFadeTween.stop();
+  }
+  backgroundFadeOverlay.setVisible(true);
+  backgroundFadeTween = scene.tweens.add({
+    targets: backgroundFadeOverlay,
+    alpha,
+    duration,
+    onComplete: () => {
+      backgroundFadeTween = null;
+      if (alpha === 0) {
+        backgroundFadeOverlay.setVisible(false);
       }
       if (onComplete) onComplete();
     }
@@ -848,7 +874,7 @@ function toggleShop(scene) {
   shopContainer.setVisible(visible);
   if (visible) {
     // Fade the game behind the shop so it appears paused and dimmed
-    fadeBackgroundWindow(scene, 0.5);
+    fadeScreenOverlay(scene, 0.5);
     showShopTab(scene, scene.activeTab || 'weapons');
     if (hideMeterEvent) {
       hideMeterEvent.remove(false);
@@ -865,7 +891,7 @@ function toggleShop(scene) {
   } else {
     // backOverlay.setVisible(backOverlayWasVisible);
     // Remove the dim when closing the shop
-    fadeBackgroundWindow(scene, 0);
+    fadeScreenOverlay(scene, 0);
     scene.physics.world.resume();
     scene.tweens.resumeAll();
     scene.time.paused = false;
@@ -981,13 +1007,13 @@ function updateTravelUI(scene) {
   });
 }
 
-function toggleTravel(scene, resume = true) {
+function toggleTravel(scene, resume = true, withFade = true) {
   const visible = !travelContainer.visible;
   travelOverlay.setVisible(visible);
   travelContainer.setVisible(visible);
   if (visible) {
     // Dim the background while the travel menu is open
-    fadeBackgroundWindow(scene, 0.5);
+    if (withFade) fadeScreenOverlay(scene, 0.5);
     updateTravelUI(scene);
     if (hideMeterEvent) {
       hideMeterEvent.remove(false);
@@ -1004,7 +1030,7 @@ function toggleTravel(scene, resume = true) {
   } else {
     // backOverlay.setVisible(backOverlayWasVisible);
     // Clear the dim when returning to gameplay
-    fadeBackgroundWindow(scene, 0);
+    if (withFade) fadeScreenOverlay(scene, 0);
     scene.physics.world.resume();
     scene.tweens.resumeAll();
     scene.time.paused = false;
@@ -1014,11 +1040,11 @@ function toggleTravel(scene, resume = true) {
 
 // Fade completely to black, change cities, then reveal the new scene.
 function travelToCity(scene, city) {
-  fadeBackgroundWindow(scene, 1, 500, () => {
-    toggleTravel(scene, false);
+  fadeScreenOverlay(scene, 1, 500, () => {
+    toggleTravel(scene, false, false);
     selectCity(scene, city);
     // After the new city is ready, fade back to gameplay
-    fadeBackgroundWindow(scene, 0, 500);
+    fadeScreenOverlay(scene, 0, 500);
   });
 }
 
@@ -1310,7 +1336,7 @@ function introExecutioner(scene, onComplete) {
   // Ensure previous background tweens don't conflict
   // scene.tweens.killTweensOf(backOverlay);
   // Darken the scene as the executioner arrives for dramatic effect
-  fadeBackgroundWindow(scene, 0.35, 800);
+  fadeBackgroundOverlay(scene, 0.35, 800);
   executioner.setPosition(850, 460);
   executioner.setAlpha(0);
   executioner.setVisible(true);


### PR DESCRIPTION
## Summary
- rename `backgroundWindowFade` to `screenFadeOverlay`
- create `backgroundFadeOverlay` that sits above the backdrop
- add helper `fadeBackgroundOverlay`
- keep menu fades but close travel menu without cancelling the black screen
- fade only the backdrop during executioner intro

## Testing
- `./scripts/update_version.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a6a65efcc8330b1ae07e25ad1a445