### PR TITLE
Delay bird spawn by 2s

### DIFF
--- a/index.html
+++ b/index.html
@@ -2255,7 +2255,7 @@ function spawnTarget(scene) {
       target.body.setAllowGravity(false);
       target.body.setImmovable(true);
       if (FEATURES.birds) {
-        spawnBird(scene);
+        scene.time.delayedCall(2000, () => spawnBird(scene));
       }
     },
     onUpdate: () => {


### PR DESCRIPTION
## Summary
- spawn birds a bit later by waiting 2 seconds before calling `spawnBird`

## Testing
- `grep -n delayedCall -n index.html | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_688d00db620883309c0caa42efd33ad9