### PR TITLE
Ensure travel overlay is cleared when changing cities

### DIFF
--- a/index.html
+++ b/index.html
@@ -1416,6 +1416,13 @@ function toggleTravel(scene, resume = true, withFade = true) {
 function travelToCity(scene, city) {
   const days = getTravelDays(currentCity, city.name);
   toggleTravel(scene, false, false);
+  // Clear any residual screen dim from the travel menu before pausing the scene
+  if (screenFadeTween) {
+    screenFadeTween.stop();
+    screenFadeTween = null;
+  }
+  screenFadeOverlay.setAlpha(0);
+  screenFadeOverlay.setVisible(false);
   scene.scene.launch('TravelScene', { city, days, mainScene: scene });
   scene.scene.pause();
 }


### PR DESCRIPTION
## Summary
- clear leftover screen fade overlay when starting travel

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e3a1ea1f48330a7ef757a3e959495