### PR TITLE
Swap bird image based on flight direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,7 +393,9 @@ function createTargetAppearance(scene, target, type) {
         break;
       }
       case 'bird': {
-        const key = target.birdKind === 'dove' ? 'birdWhite' : 'birdBlack';
+        const base = target.birdKind === 'dove' ? 'birdWhite' : 'birdBlack';
+        const direction = target.fromRight ? 'Right' : 'Left';
+        const key = base + direction;
         const img = scene.add.image(0, 0, key).setOrigin(0.5);
         target.add(img);
         break;
@@ -537,8 +539,10 @@ function preload() {
   this.load.image('jesterBody3', 'jesterbody3.png');
   this.load.image('jesterHead4', 'jesterhead4.png');
   this.load.image('jesterBody4', 'jesterbody4.png');
-  this.load.image('birdBlack', 'bird_black.png');
-  this.load.image('birdWhite', 'bird.white.png');
+  this.load.image('birdBlackLeft', 'bird_black_left.png');
+  this.load.image('birdBlackRight', 'bird_black_right.png');
+  this.load.image('birdWhiteLeft', 'bird_white_left.png');
+  this.load.image('birdWhiteRight', 'bird_white_right.png');
   // Load city backgrounds using explicit file mappings to handle inconsistent
   // naming.
   Object.entries(cityBackgrounds).forEach(([name, file]) => {
@@ -2268,6 +2272,7 @@ function spawnBird(scene) {
   const bird = scene.add.container(startX, 160).setDepth(20);
   bird.targetType = 'bird';
   bird.birdKind = kind;
+  bird.fromRight = fromRight;
   createTargetAppearance(scene, bird, 'bird');
   scene.physics.world.enable(bird);
   bird.body.setAllowGravity(false);


### PR DESCRIPTION
## Summary
- Load separate bird images for left and right directions
- Track spawn side for birds and choose matching sprite

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/choptoit/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688f4796dc2c83308918b0bdf192ee91