### PR TITLE
Add storage and weapons signs at top-left

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,8 @@ let tradeMode = 'buy';
 let tradeBuyBtns = [];
 let tradeSellBtns = [];
 let travelButton;
+let storageButton;
+let weaponsButton;
 let travelContainer;
 let travelOverlay;
 let travelRegion = null;
@@ -522,6 +524,8 @@ function preload() {
   this.load.image('escortHead', 'escorthead.png');
   this.load.image('escortBody', 'escortbody.png');
   this.load.image('signTravel', 'sign_travel.png');
+  this.load.image('signStorage', 'sign_storage.png');
+  this.load.image('signWeapons', 'sign_weapons.png');
   this.load.image('background', 'background.png');
   this.load.image('prisonerHead1', 'prisonerhead.png');
   this.load.image('prisonerBody1', 'prisonerbody.png');
@@ -956,7 +960,16 @@ function create() {
     }
   });
 
-
+  
+  // Storage and weapons signs
+  storageButton = scene.add.image(0, 0, 'signStorage')
+    .setOrigin(0, 0)
+    .setDisplaySize(107, 71)
+    .setInteractive();
+  weaponsButton = scene.add.image(120, 0, 'signWeapons')
+    .setOrigin(0, 0)
+    .setDisplaySize(107, 71)
+    .setInteractive();
 
   // Shop button
   // Move the shop button slightly right to make room for the travel sign


### PR DESCRIPTION
## Summary
- Preload storage and weapons sign assets and declare buttons for them
- Display storage and weapons signs in the screen's top-left as interactive placeholders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f66e5e26883308de29911acc75b01