### PR TITLE
feat: add smaller upgrade button

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@ let storageOverlay;
 let storageContainer;
 let storageCostText;
 let storageImage;
+let upgradeButton;
 let travelRegion = null;
 // The dimming overlay previously used during menu transitions caused a
 // distracting flash when switching cities. To remove it while keeping the
@@ -538,6 +539,7 @@ function preload() {
   this.load.image('signWeapons', 'sign_weapons.png');
   // Storage upgrade assets
   this.load.image('backgroundStorage', 'background_storage.png');
+  this.load.image('upgradeButton', 'upgrade_button.png');
   for (let i = 1; i <= 16; i++) {
     this.load.image(`storage${i}`, `storage_${i}.png`);
   }
@@ -1012,15 +1014,18 @@ function create() {
   const storageBg = scene.add.image(400, 300, 'backgroundStorage')
     .setDisplaySize(800, 600);
   storageImage = scene.add.image(400, 560, `storage${player.storageLevel}`)
+    .setOrigin(0.5, 1);
+  upgradeButton = scene.add.image(400, 520, 'upgradeButton')
     .setOrigin(0.5, 1)
+    .setScale(0.5)
     .setInteractive()
     .on('pointerdown', () => { upgradeStorage(scene); });
-  storageCostText = scene.add.text(400, 300, '', { font: '24px monospace', fill: '#ffffff' })
+  storageCostText = scene.add.text(400, 300, '', { font: '24px monospace', fill: '#ffd700' })
     .setOrigin(0.5);
-  const storageClose = scene.add.text(760, 20, '[X]', { font: '18px monospace', fill: '#ffffff' })
+  const storageClose = scene.add.text(760, 20, '[X]', { font: '18px monospace', fill: '#ffd700' })
     .setInteractive()
     .on('pointerdown', () => { toggleStorage(scene); });
-  storageContainer.add([storageBg, storageImage, storageCostText, storageClose]);
+  storageContainer.add([storageBg, storageImage, upgradeButton, storageCostText, storageClose]);
   updateStorageUI();
 
   // Travel container and overlay
@@ -1525,13 +1530,13 @@ function updateStorageUI() {
   storageImage.setTexture(`storage${player.storageLevel}`);
   if (player.storageLevel >= 16) {
     storageCostText.setText('Max Level Reached');
-    storageImage.disableInteractive();
-    storageImage.setAlpha(0.5);
+    upgradeButton.disableInteractive();
+    upgradeButton.setAlpha(0.5);
   } else {
     const cost = getStorageUpgradeCost();
     storageCostText.setText(`Upgrade Cost: ${cost} gold`);
-    storageImage.setAlpha(1);
-    storageImage.setInteractive();
+    upgradeButton.setAlpha(1);
+    upgradeButton.setInteractive();
   }
 }
 
@@ -1542,7 +1547,7 @@ function upgradeStorage(scene) {
   if (player.gold >= cost) {
     player.gold -= cost;
     goldText.setText(`Gold: ${player.gold}`);
-    storageImage.disableInteractive();
+    upgradeButton.disableInteractive();
     scene.tweens.add({
       targets: storageImage,
       scale: 1.2,


### PR DESCRIPTION
## Summary
- add upgrade button asset preload and include it on storage upgrade screen
- color storage upgrade text gold for better visibility
- handle new upgrade button interaction logic

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_688fa48967908330af7aaa23baf912ec