### PR TITLE
Adjust storage UI and bird logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     html, body {
       margin: 0;
       background: #000;
+      color: #fff;
     }
     canvas {
       display: block;
@@ -411,6 +412,7 @@ function createTargetAppearance(scene, target, type) {
         const key = base + direction;
         const img = scene.add.image(0, 0, key).setOrigin(0.5);
         target.add(img);
+        target.birdSprite = img;
         break;
       }
       default: {
@@ -1023,13 +1025,13 @@ function create() {
     .setDisplaySize(800, 600);
   storageImage = scene.add.image(400, 560, `storage${player.storageLevel}`)
     .setOrigin(0.5, 1);
-  upgradeButton = scene.add.image(400, 520, 'upgradeButton')
-    .setOrigin(0.5, 1)
+  storageCostText = scene.add.text(400, 250, '', { font: '24px monospace', fill: '#ffd700' })
+    .setOrigin(0.5);
+  upgradeButton = scene.add.image(400, 290, 'upgradeButton')
+    .setOrigin(0.5, 0)
     .setScale(0.5)
     .setInteractive()
     .on('pointerdown', () => { upgradeStorage(scene); });
-  storageCostText = scene.add.text(400, 300, '', { font: '24px monospace', fill: '#ffd700' })
-    .setOrigin(0.5);
   const storageClose = scene.add.text(760, 20, '[X]', { font: '18px monospace', fill: '#ffd700' })
     .setInteractive()
     .on('pointerdown', () => { toggleStorage(scene); });
@@ -1507,6 +1509,8 @@ function toggleStorage(scene) {
   const visible = !storageContainer.visible;
   storageOverlay.setVisible(visible);
   storageContainer.setVisible(visible);
+  if (dateBg) dateBg.setVisible(!visible);
+  if (dateText) dateText.setVisible(!visible);
   if (visible) {
     fadeScreenOverlay(scene, 0.5);
     updateStorageUI();
@@ -1518,11 +1522,17 @@ function toggleStorage(scene) {
     inputEnabled = false;
     cursor.setVisible(false);
     scene.physics.world.pause();
-    scene.tweens.pauseAll();
+    storageButton.disableInteractive();
+    shopButton.disableInteractive();
+    weaponsButton.disableInteractive();
+    travelButton.disableInteractive();
   } else {
     fadeScreenOverlay(scene, 0);
     scene.physics.world.resume();
-    scene.tweens.resumeAll();
+    storageButton.setInteractive();
+    shopButton.setInteractive();
+    weaponsButton.setInteractive();
+    travelButton.setInteractive();
     startSwingMeter(scene);
   }
 }
@@ -2424,7 +2434,13 @@ function spawnBird(scene) {
     ease: 'Linear',
     yoyo: true,
     repeat: 0,
-    onYoyo: () => bird.body.setVelocityX(-bird.body.velocity.x),
+    onYoyo: () => {
+      bird.body.setVelocityX(-bird.body.velocity.x);
+      const base = bird.birdKind === 'dove' ? 'birdWhite' : 'birdBlack';
+      const movingRight = bird.body.velocity.x > 0;
+      const dir = movingRight ? 'Right' : 'Left';
+      if (bird.birdSprite) bird.birdSprite.setTexture(base + dir);
+    },
     onComplete: () => bird.destroy()
   });
 }


### PR DESCRIPTION
## Summary
- make site text white for better contrast
- reposition storage upgrade cost and button while hiding the date
- keep weather active, disable stray inputs on storage screen, and fix bird orientation on return

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fbf6282f083308885fabb1f21df16