### PR TITLE
Show storage upgrade during travel

### DIFF
--- a/index.html
+++ b/index.html
@@ -2691,8 +2691,14 @@ class TravelScene extends Phaser.Scene {
     exec.add([body, head]);
     this.add.existing(exec);
 
+    // Storage upgrade image follows behind the executioner during travel
+    const upgrade = this.add
+      .image(-250, 560, `storage${player.storageLevel}`)
+      .setOrigin(0.5, 1);
+
     const duration = this.days * 700;
     this.tweens.add({ targets: exec, x: 900, duration, ease: 'Linear' });
+    this.tweens.add({ targets: upgrade, x: 750, duration, ease: 'Linear' });
     this.time.addEvent({
       delay: duration / this.days,
       repeat: this.days - 1,


### PR DESCRIPTION
## Summary
- Display the player's storage upgrade image trailing behind the executioner during travel
- Animate both the executioner and the upgrade cart across the screen

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc76bb844833086d0a107682df411