### PR TITLE
Adjust storage cart position during travel

### DIFF
--- a/index.html
+++ b/index.html
@@ -2695,9 +2695,9 @@ class TravelScene extends Phaser.Scene {
     exec.add([body, head]);
     this.add.existing(exec);
 
-    // Storage upgrade image trails 70px lower behind the executioner
+    // Storage upgrade image trails 50px lower behind the executioner
     const upgrade = this.add
-      .image(-250, 530, `storage${player.storageLevel}`)
+      .image(-250, 510, `storage${player.storageLevel}`)
       .setOrigin(0.5, 1)
       .setDepth(0);
 


### PR DESCRIPTION
## Summary
- Raise storage upgrade image 20px so it trails 50px below executioner during travel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fd3bb5b008330b5c8f0edbee5e894