### PR TITLE
Add black outline to multiplier and upgrade cost text

### DIFF
--- a/index.html
+++ b/index.html
@@ -778,7 +778,8 @@ function create() {
   updateXPUI();
   streakMultiplierText = scene.add.text(460, 520, 'x0', { font: '48px monospace', fill: '#ff0000' })
     .setOrigin(0.5, 1)
-    .setDepth(2);
+    .setDepth(2)
+    .setStroke('#000000', 4);
   versionText = scene.add.text(790, 590, VERSION, { font: '14px monospace', fill: '#ffffff' })
     .setOrigin(1, 1)
     .setDepth(11);
@@ -1118,7 +1119,8 @@ function create() {
   storageImage = scene.add.image(400, 560, `storage${player.storageLevel}`)
     .setOrigin(0.5, 1);
   storageCostText = scene.add.text(400, 250, '', { font: '24px monospace', fill: '#ffd700' })
-    .setOrigin(0.5);
+    .setOrigin(0.5)
+    .setStroke('#000000', 3);
   upgradeButton = scene.add.image(400, 290, 'upgradeButton')
     .setOrigin(0.5, 0)
     .setScale(0.5)
@@ -1140,7 +1142,8 @@ function create() {
   weaponsImage = scene.add.image(400, 300, `weapons${player.weaponLevel}`)
     .setOrigin(0.5);
   weaponsCostText = scene.add.text(400, 460, '', { font: '24px monospace', fill: '#ffd700' })
-    .setOrigin(0.5);
+    .setOrigin(0.5)
+    .setStroke('#000000', 3);
   weaponUpgradeButton = scene.add.image(400, 500, 'upgradeButton')
     .setOrigin(0.5, 0)
     .setScale(0.5)


### PR DESCRIPTION
## Summary
- Improve readability by adding black outline to streak multiplier numbers
- Outline storage and weapon upgrade cost text for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68948262fae8833096aae1a0ff69d215