### PR TITLE
Scale execution hit meter with weapon upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -1480,9 +1480,14 @@ function buyWeapon(scene, index) {
 }
 
 function updateZones() {
-  redZone.displayWidth = baseSizes.red + zoneMods.red;
-  yellowZone.displayWidth = baseSizes.yellow + zoneMods.yellow;
-  greenZone.displayWidth = baseSizes.green + zoneMods.green;
+  const baseYellow = baseSizes.yellow + (player.weaponLevel - 1) * 10;
+  const scale = baseYellow / baseSizes.yellow;
+  const baseRed = baseSizes.red * scale;
+  const baseGreen = baseSizes.green * scale;
+
+  redZone.displayWidth = baseRed + zoneMods.red;
+  yellowZone.displayWidth = baseYellow + zoneMods.yellow;
+  greenZone.displayWidth = baseGreen + zoneMods.green;
 }
 
 // Switch between shop tabs and update highlights
@@ -1802,6 +1807,7 @@ function upgradeWeapon(scene) {
     weaponsImage.setTexture(`weapons${player.weaponLevel}`);
     weaponsImage.setScale(4);
     updateExecutionerWeaponTexture();
+    updateZones();
     scene.tweens.add({
       targets: weaponsImage,
       scale: 1,


### PR DESCRIPTION
## Summary
- Scale execution hit meter based on weapon level
- Expand zones proportionally and refresh when upgrading weapons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895265630c48330a3a1dc160b483f00