### PR TITLE
Adjust weapon upgrade meter scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1504,7 +1504,8 @@ function buyWeapon(scene, index) {
 }
 
 function updateZones() {
-  const baseYellow = baseSizes.yellow + (player.weaponLevel - 1) * 10;
+  // Increase total meter width by 4 pixels per level (2 per end)
+  const baseYellow = baseSizes.yellow + (player.weaponLevel - 1) * (4 / 3);
   const scale = baseYellow / baseSizes.yellow;
   const baseRed = baseSizes.red * scale;
   const baseGreen = baseSizes.green * scale;


### PR DESCRIPTION
## Summary
- Scale weapon accuracy meter more gently by expanding only 2px per side per weapon level

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953f383e1c83308ca294a1ab7c8f0f