### PR TITLE
Pause game when upgrade menus are open

### DIFF
--- a/index.html
+++ b/index.html
@@ -1763,6 +1763,7 @@ function toggleStorage(scene) {
     inputEnabled = false;
     cursor.setVisible(false);
     scene.physics.world.pause();
+    scene.tweens.pauseAll();
     storageButton.disableInteractive();
     shopButton.disableInteractive();
     weaponsButton.disableInteractive();
@@ -1770,6 +1771,7 @@ function toggleStorage(scene) {
   } else {
     fadeScreenOverlay(scene, 0);
     scene.physics.world.resume();
+    scene.tweens.resumeAll();
     storageButton.setInteractive();
     shopButton.setInteractive();
     weaponsButton.setInteractive();
@@ -1840,6 +1842,7 @@ function toggleWeapons(scene) {
     inputEnabled = false;
     cursor.setVisible(false);
     scene.physics.world.pause();
+    scene.tweens.pauseAll();
     storageButton.disableInteractive();
     shopButton.disableInteractive();
     weaponsButton.disableInteractive();
@@ -1847,6 +1850,7 @@ function toggleWeapons(scene) {
   } else {
     fadeScreenOverlay(scene, 0);
     scene.physics.world.resume();
+    scene.tweens.resumeAll();
     storageButton.setInteractive();
     shopButton.setInteractive();
     weaponsButton.setInteractive();


### PR DESCRIPTION
## Summary
- Ensure gameplay tweens stop while storage and weapon upgrade menus are visible
- Resume tweens when closing upgrade menus to return to action

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68963c827fc48330a5bc777b6f834eb1