### PR TITLE
Spawn coins equal to gold earned

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,8 +565,7 @@ function addGold(scene, amount) {
   if (amount <= 0) return;
   player.gold += amount;
   goldText.setText(formatGold(player.gold));
-  const coins = Math.min(amount, 10);
-  for (let i = 0; i < coins; i++) {
+  for (let i = 0; i < amount; i++) {
     scene.time.delayedCall(i * 100, () => spawnCoin(scene));
   }
 }


### PR DESCRIPTION
## Summary
- Remove coin drop cap so the game spawns one coin for each gold earned

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/choptoit/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68963df4b8248330b3b2311816e6cd0b