### PR TITLE
feat: add day-night cycle manager

### DIFF
--- a/dayNightCycle.js
+++ b/dayNightCycle.js
@@ -1,0 +1,188 @@
+class DayNightCycle {
+  constructor(config = {}) {
+    const defaults = {
+      dayLengthSeconds: 180,
+      sunColor: 0xFFF4A3,
+      moonColor: 0xCFE3FF,
+      sunriseStart: 0.20,
+      sunriseEnd: 0.30,
+      sunsetStart: 0.70,
+      sunsetEnd: 0.80,
+      minDarkAlpha: 0.55,
+      maxLightAlpha: 0.0,
+    };
+    this.config = { ...defaults, ...config };
+
+    this.scene = null;
+    this.timeOfDay = 0; // 0..1
+    this.elapsed = 0;
+    this.currentDayCount = 0;
+    this.executionsThisDay = 0;
+    this.lastHour = -1;
+
+    // game object references
+    this.container = null;
+    this.sun = null;
+    this.moon = null;
+    this.overlay = null;
+
+    // callbacks
+    this.fullDayHandlers = [];
+    this.hourHandlers = [];
+  }
+
+  /**
+   * Create visual elements and overlay. Call from scene.create().
+   * @param {Phaser.Scene} scene
+   * @param {object} layers - depth configuration
+   * @param {number} layers.backCloudsDepth - depth of back cloud layer
+   * @param {number} [layers.overlayDepth] - depth for the lighting overlay
+   */
+  init(scene, layers = {}) {
+    this.scene = scene;
+    const { backCloudsDepth = 0, overlayDepth = 28.9 } = layers;
+
+    // Container for sun and moon positioned behind back clouds
+    this.container = scene.add.container(0, 0).setDepth(backCloudsDepth - 1);
+
+    // Create sun
+    this.sun = scene.add.circle(0, 0, 30, this.config.sunColor);
+    this.sun.setAlpha(0);
+    this.container.add(this.sun);
+
+    // Create crescent moon texture via graphics
+    const gfx = scene.add.graphics();
+    gfx.fillStyle(this.config.moonColor, 1);
+    gfx.fillCircle(20, 20, 20);
+    gfx.fillStyle(0x000000, 1);
+    gfx.fillCircle(28, 20, 20);
+    gfx.generateTexture('crescent-moon', 40, 40);
+    gfx.destroy();
+
+    this.moon = scene.add.image(0, 0, 'crescent-moon');
+    this.moon.setAlpha(1);
+    this.container.add(this.moon);
+
+    // Fullscreen light/dark overlay
+    this.overlay = scene.add.rectangle(
+      scene.scale.width / 2,
+      scene.scale.height / 2,
+      scene.scale.width,
+      scene.scale.height,
+      0x000000,
+      1
+    );
+    this.overlay.setDepth(overlayDepth);
+    this.overlay.setScrollFactor(0);
+    this.overlay.setAlpha(this.config.minDarkAlpha);
+
+    return this;
+  }
+
+  setDayLength(seconds) {
+    this.config.dayLengthSeconds = seconds;
+  }
+
+  getTimeOfDay() {
+    return this.timeOfDay;
+  }
+
+  onFullDay(cb) {
+    if (cb) this.fullDayHandlers.push(cb);
+  }
+
+  onHourlyExecution(cb) {
+    if (cb) this.hourHandlers.push(cb);
+  }
+
+  update(deltaSeconds) {
+    if (!this.scene) return;
+    const prev = this.timeOfDay;
+    this.timeOfDay = (this.timeOfDay + deltaSeconds / this.config.dayLengthSeconds) % 1;
+
+    // Day wrap
+    if (this.timeOfDay < prev) {
+      this.executionsThisDay = 0;
+      this.currentDayCount++;
+      this.fullDayHandlers.forEach(fn => fn(this.currentDayCount));
+    }
+
+    // Hourly execution
+    const currentHour = Math.floor(this.timeOfDay * 24);
+    if (currentHour !== this.lastHour) {
+      this.lastHour = currentHour;
+      if (this.executionsThisDay < 24) {
+        this.executionsThisDay++;
+        this.hourHandlers.forEach(fn => fn(currentHour));
+      }
+    }
+
+    this.updateOverlay();
+    this.updateCelestials();
+  }
+
+  // Smoothly adjust overlay alpha based on time of day
+  updateOverlay() {
+    if (!this.overlay) return;
+    const { minDarkAlpha, maxLightAlpha } = this.config;
+    const alpha =
+      minDarkAlpha +
+      (maxLightAlpha - minDarkAlpha) * 0.5 *
+        (1 - Math.cos(this.timeOfDay * Math.PI * 2));
+    this.overlay.setAlpha(alpha);
+  }
+
+  // Position and fade the sun and moon
+  updateCelestials() {
+    const { sunriseStart, sunriseEnd, sunsetStart, sunsetEnd } = this.config;
+    const width = this.scene.scale.width;
+    const baseY = 120;
+    const arc = 80;
+    const t = this.timeOfDay;
+
+    // --- Sun ---
+    if (t >= sunriseStart && t <= sunsetEnd) {
+      const sunT = Phaser.Math.Clamp((t - sunriseStart) / (sunsetEnd - sunriseStart), 0, 1);
+      const angle = sunT * Math.PI;
+      this.sun.setPosition(width * sunT, baseY - Math.sin(angle) * arc);
+      if (t < sunriseEnd) {
+        const p = (t - sunriseStart) / (sunriseEnd - sunriseStart);
+        this.sun.setAlpha(Phaser.Math.Easing.Quadratic.InOut(p));
+      } else if (t > sunsetStart) {
+        const p = 1 - (t - sunsetStart) / (sunsetEnd - sunsetStart);
+        this.sun.setAlpha(Phaser.Math.Easing.Quadratic.InOut(p));
+      } else {
+        this.sun.setAlpha(1);
+      }
+    } else {
+      this.sun.setAlpha(0);
+    }
+
+    // --- Moon ---
+    const nightLength = (1 - sunsetEnd) + sunriseStart;
+    let moonT;
+    if (t >= sunsetEnd) {
+      moonT = (t - sunsetEnd) / nightLength;
+    } else {
+      moonT = (t + (1 - sunsetEnd)) / nightLength;
+    }
+    const moonAngle = moonT * Math.PI;
+    this.moon.setPosition(width * moonT, baseY - Math.sin(moonAngle) * arc);
+
+    let moonAlpha = 0;
+    if (t >= sunsetStart && t <= sunsetEnd) {
+      const p = (t - sunsetStart) / (sunsetEnd - sunsetStart);
+      moonAlpha = Phaser.Math.Easing.Quadratic.InOut(p);
+    } else if (t >= sunriseStart && t <= sunriseEnd) {
+      const p = 1 - (t - sunriseStart) / (sunriseEnd - sunriseStart);
+      moonAlpha = Phaser.Math.Easing.Quadratic.InOut(p);
+    } else if (t <= sunriseStart || t >= sunsetEnd) {
+      moonAlpha = 1;
+    }
+    this.moon.setAlpha(moonAlpha);
+  }
+}
+
+// Expose globally
+window.DayNightCycle = DayNightCycle;
+

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/phaser@3.55.2/dist/phaser.js"></script>
+  <script src="dayNightCycle.js"></script>
 </head>
 <body>
 
@@ -562,6 +563,11 @@ function advanceDays(days = 1) {
   dailyMarketUpdate();
 }
 
+// Alias used by the day/night cycle to advance time
+function advanceCalendarDays(days = 1) {
+  advanceDays(days);
+}
+
 function isMenuOpen() {
   return (shopContainer && shopContainer.visible) ||
          (travelContainer && travelContainer.visible) ||
@@ -691,7 +697,8 @@ function create() {
   // Background and stage art
   skyRect = scene.add.image(400, 300, 'backgroundSky');
   skyRect.setDisplaySize(800, 600);
-  skyRect.setDepth(-4);
+  // Render sky behind celestial bodies
+  skyRect.setDepth(-5);
 
   backgroundRect = scene.add.image(400, 300, 'background');
   backgroundRect.setDisplaySize(800, 600);
@@ -753,6 +760,12 @@ function create() {
       cloudLayerNear.add(cloud);
     }
   }
+
+  // Initialize day/night cycle
+  this.dayNight = new DayNightCycle({ dayLengthSeconds: 180 });
+  this.dayNight.init(scene, { backCloudsDepth: -3, overlayDepth: 28.9 });
+  this.dayNight.onFullDay(() => { advanceCalendarDays(1); });
+  this.dayNight.onHourlyExecution(() => { startExecutionRound(); });
 
   stage = scene.add.image(400, 520, 'platform').setDepth(0);
   stageBlood = scene.add.rectangle(400, 520, 1, 10, 0x770000)
@@ -2455,6 +2468,16 @@ function spawnPrisoner(scene, fromRight, withTarget = true) {
   scene.tweens.add({ targets: rightEscort, x: 450, duration: 1500, ease: 'Linear' });
 }
 
+// Wrapper for the hourly execution callback
+function startExecutionRound() {
+  if (game && game.scene && game.scene.scenes.length) {
+    const scene = game.scene.scenes[0];
+    // Randomize which side the prisoner enters from
+    const fromRight = Phaser.Math.Between(0, 1) === 1;
+    spawnPrisoner(scene, fromRight);
+  }
+}
+
 function startSwingMeter(scene) {
   if (hideMeterEvent) {
     hideMeterEvent.remove(false);
@@ -2972,6 +2995,10 @@ function onLevelUp(scene) {
 
 function update(time, delta) {
 
+  if (this.dayNight) {
+    this.dayNight.update(delta / 1000);
+  }
+
   if (FEATURES.clouds && cloudLayerFar && cloudLayerNear) {
     cloudLayerFar.getChildren().forEach(cloud => {
       cloud.x -= 0.2;
@@ -3044,7 +3071,7 @@ class TravelScene extends Phaser.Scene {
     const keys = travelBackgrounds.map((_, i) => `background-travel${i + 1}`);
     let bgKey = Phaser.Utils.Array.GetRandom(keys);
     if (!this.textures.exists(bgKey)) bgKey = 'background';
-    this.add.image(400, 300, 'backgroundSky').setDisplaySize(800, 600).setDepth(-4);
+    this.add.image(400, 300, 'backgroundSky').setDisplaySize(800, 600).setDepth(-5);
     this.add.image(400, 300, bgKey).setDisplaySize(800, 600).setDepth(-2);
     this.add.text(400, 40, `Travelling to ${this.city.name}`, { font: '32px serif', fill: '#ffff00' }).setOrigin(0.5);
     let d = currentDay;


### PR DESCRIPTION
## Summary
- add DayNightCycle manager with sun/moon movement, light overlay, and hourly callbacks
- hook the manager into the scene to advance calendar days and trigger execution rounds
- expose helper functions for calendar and execution round

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/choptoit/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6896443949808330b3c7f5e58bf67145