### PR TITLE
Shift gold and fame counters downward

### DIFF
--- a/index.html
+++ b/index.html
@@ -876,7 +876,7 @@ function create() {
     .setOrigin(0.5, 1)
     .setDepth(100)
     .setVisible(false);
-  goldText = scene.add.text(chest.x, chest.y - 10, formatGold(player.gold), { font: '20px monospace', fill: '#ffff88' })
+  goldText = scene.add.text(chest.x, chest.y - 5, formatGold(player.gold), { font: '20px monospace', fill: '#ffff88' })
     .setOrigin(0.5, 1)
     .setDepth(101)
     .setScrollFactor(0)


### PR DESCRIPTION
## Summary
- Move gold display 5px lower to better align with chest UI.
- Fame counter remains anchored to gold, following the same downward shift.

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6896f1265a908330a62fa7d38db3a503