### PR TITLE
Expand trade menu overlay for close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1446,10 +1446,10 @@ function create() {
     .setVisible(false)
     // Use a depth above the shop container so this overlay appears on top
     .setDepth(202);
-  tradeContainer = scene.add.container(190, 300).setVisible(false).setDepth(203);
-  const tradeBg = scene.add.rectangle(0, 0, 420, 160, 0x222222, 1).setOrigin(0, 0);
+  tradeContainer = scene.add.container(120, 300).setVisible(false).setDepth(203);
+  const tradeBg = scene.add.rectangle(0, 0, 560, 200, 0x222222, 1).setOrigin(0, 0);
   tradeBg.setStrokeStyle(2, 0xffffff);
-  tradeTitle = scene.add.text(210, 10, '', { font: '18px monospace', fill: '#ffffaa' })
+  tradeTitle = scene.add.text(280, 10, '', { font: '18px monospace', fill: '#ffffaa' })
     .setOrigin(0.5, 0);
   const b1 = scene.add.text(20, 50, '[Buy 1]', { font: '18px monospace', fill: '#00ff00' })
     .setInteractive()
@@ -1458,7 +1458,7 @@ function create() {
       if (item.stock > 0) buyMarketItem(scene, tradeItemIndex, 1);
       hideTradeMenu(scene);
     });
-  const b10 = scene.add.text(160, 50, '[Buy 10]', { font: '18px monospace', fill: '#00ff00' })
+  const b10 = scene.add.text(180, 50, '[Buy 10]', { font: '18px monospace', fill: '#00ff00' })
     .setInteractive()
     .on('pointerdown', () => {
       const item = marketItems[tradeItemIndex];
@@ -1466,7 +1466,7 @@ function create() {
       if (qty > 0) buyMarketItem(scene, tradeItemIndex, qty);
       hideTradeMenu(scene);
     });
-  const bMax = scene.add.text(300, 50, '[Buy Max]', { font: '18px monospace', fill: '#00ff00' })
+  const bMax = scene.add.text(340, 50, '[Buy Max]', { font: '18px monospace', fill: '#00ff00' })
     .setInteractive()
     .on('pointerdown', () => {
       const item = marketItems[tradeItemIndex];
@@ -1479,10 +1479,10 @@ function create() {
   const s1 = scene.add.text(20, 90, '[Sell 1]', { font: '18px monospace', fill: '#00ff00' })
     .setInteractive()
     .on('pointerdown', () => { sellMarketItem(scene, tradeItemIndex, 1); hideTradeMenu(scene); });
-  const s10 = scene.add.text(160, 90, '[Sell 10]', { font: '18px monospace', fill: '#00ff00' })
+  const s10 = scene.add.text(180, 90, '[Sell 10]', { font: '18px monospace', fill: '#00ff00' })
     .setInteractive()
     .on('pointerdown', () => { sellMarketItem(scene, tradeItemIndex, 10); hideTradeMenu(scene); });
-  const sMax = scene.add.text(300, 90, '[Sell Max]', { font: '18px monospace', fill: '#00ff00' })
+  const sMax = scene.add.text(340, 90, '[Sell Max]', { font: '18px monospace', fill: '#00ff00' })
     .setInteractive()
     .on('pointerdown', () => {
       const item = marketItems[tradeItemIndex];
@@ -1490,7 +1490,7 @@ function create() {
       if (max > 0) sellMarketItem(scene, tradeItemIndex, max);
       hideTradeMenu(scene);
     });
-  const tradeClose = scene.add.image(300, 0, 'signClose')
+  const tradeClose = scene.add.image(440, 0, 'signClose')
     .setOrigin(0, 0)
     .setDisplaySize(100, 100)
     .setInteractive()


### PR DESCRIPTION
## Summary
- Widen and heighten the trade menu background to 560x200 and recenter container
- Reposition buy/sell buttons and close sign so the X no longer overlaps menu content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f892332c8330b45a8a19c0fe0589