### PR TITLE
Round weapon upgrade costs to whole integers

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,8 @@ const player = {
   weaponLevel: 1,
 };
 
+const WEAPON_UPGRADE_RATIO = Math.pow(2000000 / 10, 1 / 28);
+
 function formatGold(amount) {
   if (amount < 1000) return amount.toString();
   const units = ['k', 'M', 'B', 'T'];
@@ -1977,7 +1979,8 @@ function toggleWeapons(scene) {
 
 // Cost to upgrade to the next weapon level
 function getWeaponUpgradeCost() {
-  return 10 * Math.pow(2, player.weaponLevel - 1);
+  const cost = 10 * Math.pow(WEAPON_UPGRADE_RATIO, player.weaponLevel - 1);
+  return Math.ceil(cost - 1e-6);
 }
 
 // Refresh weapon image, upgrade cost text, and interactivity


### PR DESCRIPTION
## Summary
- ensure weapon upgrade costs scale to 2,000,000 gold at level 30 and always round up to whole pieces

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897913073cc833085eac079e89de177