### PR TITLE
Align trader dialogue bubble and peasant placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -975,12 +975,14 @@ let marketTypeEvent;
 function updateSpeechBubble() {
   if (!marketChatterText || !marketChatterBubble) return;
   const padding = 10;
-  const width = marketChatterText.width + padding * 2;
-  const height = marketChatterText.height + padding * 2;
+  const bounds = marketChatterText.getBounds();
+  const width = bounds.width + padding * 2;
+  const height = bounds.height + padding * 2;
   marketChatterBubble.setSize(width, height);
-  marketChatterBubble.setPosition(marketChatterText.x - 200, marketChatterText.y);
+  marketChatterBubble.setPosition(marketChatterText.x, marketChatterText.y);
   if (marketPrisoner) {
-    marketPrisoner.x = marketChatterBubble.x + width / 2 + 10;
+    const peasantWidth = marketPrisoner.width || 0;
+    marketPrisoner.x = marketChatterBubble.x + width / 2 + peasantWidth / 2 + 10;
     marketPrisoner.y = marketChatterBubble.y + height / 2;
   }
 }


### PR DESCRIPTION
## Summary
- Align market chatter text within its speech bubble
- Keep peasant avatar to the right of the bubble without overlap

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897bf5a793c833091fb4d940f4378aa