### PR TITLE
Adjust trading menu speech bubble and trader positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -979,11 +979,11 @@ function updateSpeechBubble() {
   const width = bounds.width + padding * 2;
   const height = bounds.height + padding * 2;
   marketChatterBubble.setSize(width, height);
-  marketChatterBubble.setPosition(marketChatterText.x, marketChatterText.y);
+  marketChatterBubble.setPosition(marketChatterText.x - 200, marketChatterText.y);
   if (marketPrisoner) {
     const peasantWidth = marketPrisoner.width || 0;
-    marketPrisoner.x = marketChatterBubble.x + width / 2 + peasantWidth / 2 + 10;
-    marketPrisoner.y = marketChatterBubble.y + height / 2;
+    marketPrisoner.x = marketChatterText.x + width / 2 + peasantWidth / 2 + 10;
+    marketPrisoner.y = marketChatterBubble.y + height / 2 + 100;
   }
 }
 
@@ -1953,7 +1953,7 @@ function create() {
     wordWrap: { width: 640 }
   }).setOrigin(0.5)
     .setStroke('#000000', 3);
-  marketChatterBubble = scene.add.rectangle(400, 300, 10, 10, 0xffffff, 1)
+  marketChatterBubble = scene.add.rectangle(marketChatterText.x - 200, marketChatterText.y, 10, 10, 0xffffff, 1)
     .setOrigin(0.5)
     .setStrokeStyle(2, 0x000000);
   const body = scene.add.image(0, 0, 'prisonerBody1').setOrigin(0.5, 1).setScale(1);


### PR DESCRIPTION
## Summary
- Shift market speech bubble 200px left while keeping text centered
- Keep peasant trader horizontally fixed, dropping him 100px lower
- Initialize bubble with the new offset to avoid initial jump

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898391feea08330acb4a99665e7daa6