### PR TITLE
Center speech text

### DIFF
--- a/index.html
+++ b/index.html
@@ -979,7 +979,7 @@ function updateSpeechBubble() {
   const width = bounds.width + padding * 2;
   const height = bounds.height + padding * 2;
   marketChatterBubble.setSize(width, height);
-  marketChatterBubble.setPosition(marketChatterText.x - 300, marketChatterText.y - 15);
+  marketChatterBubble.setPosition(marketChatterText.x, marketChatterText.y);
   if (marketPrisoner) {
     const peasantWidth = marketPrisoner.width || 0;
     marketPrisoner.x = marketChatterText.x + width / 2 + peasantWidth / 2 + 10;
@@ -1847,7 +1847,8 @@ function create() {
   weaponQuoteText = scene.add.text(400, 300, '', {
     font: '20px monospace',
     fill: '#ffaaaa',
-    wordWrap: { width: 300 }
+    wordWrap: { width: 300 },
+    align: 'center'
   }).setOrigin(0.5)
     .setStroke('#000000', 3);
   weaponQuoteBubble = scene.add.rectangle(400, 300, 10, 10, 0xffffff, 1)
@@ -1950,10 +1951,11 @@ function create() {
   marketChatterText = scene.add.text(400, 300, '', {
     font: '20px monospace',
     fill: '#ffaaaa',
-    wordWrap: { width: 640 }
+    wordWrap: { width: 640 },
+    align: 'center'
   }).setOrigin(0.5)
     .setStroke('#000000', 3);
-  marketChatterBubble = scene.add.rectangle(marketChatterText.x - 300, marketChatterText.y - 15, 10, 10, 0xffffff, 1)
+  marketChatterBubble = scene.add.rectangle(marketChatterText.x, marketChatterText.y, 10, 10, 0xffffff, 1)
     .setOrigin(0.5)
     .setStrokeStyle(2, 0x000000);
   const body = scene.add.image(0, 0, 'prisonerBody1').setOrigin(0.5, 1).setScale(1);


### PR DESCRIPTION
## Summary
- Center market speech bubble positioning to align with its text
- Center-align both market and weapon speech text within bubbles

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/choptoit/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6898934fd99483309be1c196af71ff6d