### PR TITLE
Adjust weapon upgrade layout and travel pass color

### DIFF
--- a/index.html
+++ b/index.html
@@ -1842,12 +1842,13 @@ function create() {
     .setDisplaySize(800, 600);
   const weaponsBg = scene.add.image(400, 300, 'backgroundWeapons')
     .setDisplaySize(800, 600);
-  weaponsImage = scene.add.image(400, 300, `weapons${player.weaponLevel}`)
+  // Raise weapon image, cost text, and upgrade button for better layout
+  weaponsImage = scene.add.image(400, 250, `weapons${player.weaponLevel}`)
     .setOrigin(0.5);
-  weaponsCostText = scene.add.text(400, 360, '', { font: '24px monospace', fill: '#ffd700' })
+  weaponsCostText = scene.add.text(400, 310, '', { font: '24px monospace', fill: '#ffd700' })
     .setOrigin(0.5)
     .setStroke('#000000', 3);
-  weaponUpgradeButton = scene.add.image(400, 420, 'upgradeButton')
+  weaponUpgradeButton = scene.add.image(400, 370, 'upgradeButton')
     .setOrigin(0.5, 0)
     .setScale(0.5)
     .setInteractive()
@@ -2267,7 +2268,7 @@ function updateTravelUI(scene) {
     } else if (locked) {
       const affordable = fame >= nextCityKeyCost;
       c.ui.btn.setText(`[Buy Key: ${nextCityKeyCost} Fame]`);
-      c.ui.btn.setFill(affordable ? '#ffff00' : '#777777');
+      c.ui.btn.setFill(affordable ? '#00ff00' : '#777777');
     } else {
       c.ui.btn.setText('[Go]');
       c.ui.btn.setFill('#00ff00');


### PR DESCRIPTION
## Summary
- Raise weapon image, cost text, and upgrade button on the weapon upgrade screen
- Show green text for affordable city passes in the travel menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e9c2bcc88330bc3341763316b315