### PR TITLE
Stop gameplay interaction when upgrade menus open

### DIFF
--- a/index.html
+++ b/index.html
@@ -2064,11 +2064,12 @@ function create() {
     if (swingActive && inputEnabled) endSwing(scene);
   });
   scene.input.on('pointerdown', () => {
+    if (!inputEnabled) return;
     if (awaitingAngle) {
       chooseAngle(scene);
     } else if (awaitingPower) {
       choosePower(scene);
-    } else if (swingActive && inputEnabled) {
+    } else if (swingActive) {
       endSwing(scene);
     }
   });


### PR DESCRIPTION
## Summary
- Ignore pointer input when gameplay is disabled so clicks on upgrade screens don't register as hits or misses.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ee558f54833080948a4f38a79be2