### PR TITLE
Shift travel Buy Key button 10px right

### DIFF
--- a/index.html
+++ b/index.html
@@ -2313,7 +2313,7 @@ function showTravelMenu(scene, region = travelRegion) {
       fill: '#ffffaa',
       wordWrap: { width: 320 }
     }).setStroke('#000000', 3);
-    const btn = scene.add.text(240, y, '[Go]', {
+    const btn = scene.add.text(250, y, '[Go]', {
       font: '18px monospace',
       fill: '#00ff00'
     })


### PR DESCRIPTION
## Summary
- move travel menu action button 10px to the right to give Buy Key text more space from city names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f415104c8330be5443c248adbf6a