### PR TITLE
Align speech bubble widths on upgrade screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -2094,7 +2094,7 @@ function create() {
   storageQuoteText = scene.add.text(0, 0, '', {
     font: '20px monospace',
     fill: '#ffaaaa',
-    wordWrap: { width: 300 },
+    wordWrap: { width: 640 },
     align: 'center'
   }).setOrigin(0.5)
     .setStroke('#000000', 3);
@@ -2145,7 +2145,7 @@ function create() {
   weaponQuoteText = scene.add.text(0, 0, '', {
     font: '20px monospace',
     fill: '#ffaaaa',
-    wordWrap: { width: 300 },
+    wordWrap: { width: 640 },
     align: 'center'
   }).setOrigin(0.5)
     .setStroke('#000000', 3);


### PR DESCRIPTION
## Summary
- Match weapon and storage quote bubble width to trading screen bubble width

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990aaebb988330b0c0441d4385ee89