### PR TITLE
Improve exploding barrel hit detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -3860,16 +3860,17 @@ function spawnTarget(scene) {
     ease: 'Linear',
     onComplete: () => {
       scene.physics.world.enable(target);
-      if (type === 'explodingBarrel') {
-        // Include the fuse above the barrel in the hitbox
-        target.body.setSize(30, 46);
-        target.body.setOffset(-15, -26);
-      } else {
-        target.body.setCircle(20);
-        target.body.setOffset(-20, -20);
-        target.body.x = target.x - target.body.halfWidth;
-        target.body.y = target.y - target.body.halfHeight;
-      }
+        if (type === 'explodingBarrel') {
+          // Include the fuse above the barrel in the hitbox and widen it slightly
+          // so the barrels are a bit easier to hit.
+          target.body.setSize(40, 56);
+          target.body.setOffset(-20, -30);
+        } else {
+          target.body.setCircle(20);
+          target.body.setOffset(-20, -20);
+          target.body.x = target.x - target.body.halfWidth;
+          target.body.y = target.y - target.body.halfHeight;
+        }
       target.body.setAllowGravity(false);
       target.body.setImmovable(true);
       if (FEATURES.birds && Phaser.Math.Between(1, 10) === 1) {


### PR DESCRIPTION
## Summary
- Widen exploding barrel physics body so fuse and edges are easier to hit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991a3638dc833081ba240fa3875749