### PR TITLE
feat: adjust weapon upgrade button position

### DIFF
--- a/index.html
+++ b/index.html
@@ -2137,7 +2137,7 @@ function create() {
   weaponsCostText = scene.add.text(400, 310, '', { font: '24px monospace', fill: '#ffd700' })
     .setOrigin(0.5)
     .setStroke('#000000', 3);
-  weaponUpgradeButton = scene.add.image(400, 370, 'upgradeButton')
+  weaponUpgradeButton = scene.add.image(400, 320, 'upgradeButton')
     .setOrigin(0.5, 0)
     .setScale(0.5)
     .setInteractive()


### PR DESCRIPTION
## Summary
- Move weapon upgrade button up 50 pixels for better layout on upgrade screen

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/choptoit/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6899cc02a9f48330a4af6768391e8fde