### PR TITLE
Adjust UI elements and randomize peasant appearance

### DIFF
--- a/index.html
+++ b/index.html
@@ -853,6 +853,7 @@ let roundCount = 0;
 let weatherText;
 let weatherIndicator;
 let weatherIndicatorBg;
+let menuIcon;
 
 // Inventory for trading market items
 let inventory = {};
@@ -1672,13 +1673,18 @@ function create() {
     .setDepth(50)
     .setVisible(false);
   weatherText.setY(weatherText.y + 50);
-  weatherIndicatorBg = scene.add.circle(25, 571, 24, 0x000000)
+  weatherIndicatorBg = scene.add.circle(25, 471, 24, 0x000000)
     .setOrigin(0.5)
     .setDepth(49)
     .setVisible(false);
-  weatherIndicator = scene.add.text(25, 571, '', { font: '20px monospace', fill: '#ffffff' })
+  weatherIndicator = scene.add.text(25, 471, '', { font: '20px monospace', fill: '#ffffff' })
     .setOrigin(0.5)
     .setDepth(50)
+    .setVisible(false);
+  menuIcon = scene.add.text(25, 571, '\u2630', { font: '32px monospace', fill: '#ffffff' })
+    .setOrigin(0.5)
+    .setDepth(1000)
+    .setScrollFactor(0)
     .setVisible(false);
 
   // Debug cheat: hold the weather icon for 10 seconds to gain resources
@@ -1794,6 +1800,7 @@ function create() {
         logoContainer.setVisible(false);
         weatherIndicatorBg.setVisible(true);
         weatherIndicator.setVisible(true);
+        menuIcon.setVisible(true);
         dateBg.setVisible(true);
         dateText.setVisible(true);
         locationText.setVisible(true);
@@ -3049,8 +3056,10 @@ function beheadPrisoner(scene, bloodAmount, angleDeg, power = 1) {
   // Create a physics body using the prisoner sprite for the falling corpse
   const corpse = scene.add.image(prisoner.x, prisoner.y + 50, prisonerBodyKey)
     .setOrigin(0.5, 1)
-    .setDepth(0.5)
-    .setTint(prisonerClass.color);
+    .setDepth(0.5);
+  if (prisonerClass.name !== 'Clergy') {
+    corpse.setTint(prisonerClass.color);
+  }
   scene.physics.world.enable(corpse);
   bodyGroup.add(corpse);
   corpse.isCorpse = true;
@@ -3322,10 +3331,13 @@ function spawnPrisoner(scene, fromRight, withTarget = true) {
   if (prisonerClass.name === 'Clergy') {
     prisonerHeadKey = 'priestHead';
     prisonerBodyKey = 'priestBody';
-  } else {
+  } else if (prisonerClass.name === 'Peasant') {
     const variant = Phaser.Math.Between(1, 3);
     prisonerHeadKey = `prisonerHead${variant}`;
     prisonerBodyKey = `prisonerBody${variant}`;
+  } else {
+    prisonerHeadKey = 'prisonerHead1';
+    prisonerBodyKey = 'prisonerBody1';
   }
   prisonerBody.setTexture(prisonerBodyKey);
   prisonerHeadSprite.setTexture(prisonerHeadKey);
@@ -3337,7 +3349,10 @@ function spawnPrisoner(scene, fromRight, withTarget = true) {
       spawnTarget(scene);
     }
   }
-  prisonerBody.setTint(prisonerClass.color);
+  prisonerBody.clearTint();
+  if (prisonerClass.name !== 'Clergy') {
+    prisonerBody.setTint(prisonerClass.color);
+  }
   baseSwingSpeed = prisonerClass.speed;
   swingSpeed = baseSwingSpeed * speedMultiplier;
   // Keep body aligned under the head when resetting for a new prisoner


### PR DESCRIPTION
## Summary
- Move weather indicator and cheat trigger higher and add persistent bottom-left menu icon
- Remove purple tint from priest class and randomize peasant body and head

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899e98bb5c4833099c77edac2e1bf68