### PR TITLE
Randomize prisoner heads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1455,12 +1455,16 @@ function preload() {
   }
   this.load.image('background', 'background.png');
   this.load.image('backgroundSky', 'background_bluesky.png');
-  this.load.image('prisonerHead1', 'prisonerhead.png');
-  this.load.image('prisonerBody1', 'prisonerbody.png');
-  this.load.image('prisonerHead2', 'prisonerhead2.png');
-  this.load.image('prisonerBody2', 'prisonerbody2.png');
-  this.load.image('prisonerHead3', 'prisonerhead3.png');
-  this.load.image('prisonerBody3', 'prisonerbody3.png');
+  for (let i = 1; i <= 20; i++) {
+    const headKey = `prisonerHead${i}`;
+    const headFile = i === 1 ? 'prisonerhead.png' : `prisonerhead${i}.png`;
+    this.load.image(headKey, headFile);
+  }
+  for (let i = 1; i <= 3; i++) {
+    const bodyKey = `prisonerBody${i}`;
+    const bodyFile = i === 1 ? 'prisonerbody.png' : `prisonerbody${i}.png`;
+    this.load.image(bodyKey, bodyFile);
+  }
   this.load.image('priestHead', 'prisonerhead_priest.png');
   this.load.image('priestBody', 'prisonerbody_priest.png');
   this.load.image('jesterHead1', 'jesterhead.png');
@@ -2108,8 +2112,10 @@ function create() {
   storageQuoteBubble = scene.add.rectangle(0, 0, 10, 10, 0xffffff, 1)
     .setOrigin(0.5)
     .setStrokeStyle(2, 0x000000);
-  const sqBody = scene.add.image(0, 0, 'prisonerBody1').setOrigin(0.5, 1).setScale(1);
-  const sqHead = scene.add.image(0, -80, 'prisonerHead1').setOrigin(0.5).setScale(1);
+  const sqBodyKey = `prisonerBody${Phaser.Math.Between(1, 3)}`;
+  const sqHeadKey = `prisonerHead${Phaser.Math.Between(1, 20)}`;
+  const sqBody = scene.add.image(0, 0, sqBodyKey).setOrigin(0.5, 1).setScale(1);
+  const sqHead = scene.add.image(0, -80, sqHeadKey).setOrigin(0.5).setScale(1);
   storagePeasant = scene.add.container(0, 0, [sqBody, sqHead]);
   storagePeasant.setPosition(400, 550);
   upgradeButton = scene.add.image(400, 290, 'upgradeButton')
@@ -2159,8 +2165,10 @@ function create() {
   weaponQuoteBubble = scene.add.rectangle(0, 0, 10, 10, 0xffffff, 1)
     .setOrigin(0.5)
     .setStrokeStyle(2, 0x000000);
-  const wqBody = scene.add.image(0, 0, 'prisonerBody1').setOrigin(0.5, 1).setScale(1);
-  const wqHead = scene.add.image(0, -80, 'prisonerHead1').setOrigin(0.5).setScale(1);
+  const wqBodyKey = `prisonerBody${Phaser.Math.Between(1, 3)}`;
+  const wqHeadKey = `prisonerHead${Phaser.Math.Between(1, 20)}`;
+  const wqBody = scene.add.image(0, 0, wqBodyKey).setOrigin(0.5, 1).setScale(1);
+  const wqHead = scene.add.image(0, -80, wqHeadKey).setOrigin(0.5).setScale(1);
   weaponPeasant = scene.add.container(0, 0, [wqBody, wqHead]);
   weaponPeasant.setPosition(400, 550);
   const weaponsClose = scene.add.image(700, 0, 'signClose')
@@ -2268,8 +2276,10 @@ function create() {
   marketChatterBubble = scene.add.rectangle(0, 0, 10, 10, 0xffffff, 1)
     .setOrigin(0.5)
     .setStrokeStyle(2, 0x000000);
-  const body = scene.add.image(0, 0, 'prisonerBody1').setOrigin(0.5, 1).setScale(1);
-  const head = scene.add.image(0, -80, 'prisonerHead1').setOrigin(0.5).setScale(1);
+  const bodyKey = `prisonerBody${Phaser.Math.Between(1, 3)}`;
+  const headKey = `prisonerHead${Phaser.Math.Between(1, 20)}`;
+  const body = scene.add.image(0, 0, bodyKey).setOrigin(0.5, 1).setScale(1);
+  const head = scene.add.image(0, -80, headKey).setOrigin(0.5).setScale(1);
   marketPrisoner = scene.add.container(400, 550, [body, head]);
   shopContainer.add(marketChatterBubble);
   shopContainer.add(marketChatterText);
@@ -3331,13 +3341,11 @@ function spawnPrisoner(scene, fromRight, withTarget = true) {
   if (prisonerClass.name === 'Clergy') {
     prisonerHeadKey = 'priestHead';
     prisonerBodyKey = 'priestBody';
-  } else if (prisonerClass.name === 'Peasant') {
-    const variant = Phaser.Math.Between(1, 3);
-    prisonerHeadKey = `prisonerHead${variant}`;
-    prisonerBodyKey = `prisonerBody${variant}`;
   } else {
-    prisonerHeadKey = 'prisonerHead1';
-    prisonerBodyKey = 'prisonerBody1';
+    const headVariant = Phaser.Math.Between(1, 20);
+    const bodyVariant = Phaser.Math.Between(1, 3);
+    prisonerHeadKey = `prisonerHead${headVariant}`;
+    prisonerBodyKey = `prisonerBody${bodyVariant}`;
   }
   prisonerBody.setTexture(prisonerBodyKey);
   prisonerHeadSprite.setTexture(prisonerHeadKey);


### PR DESCRIPTION
## Summary
- Load all 20 prisoner head images and randomly choose a head and body for each prisoner spawn
- Show random prisoner heads in storage, weapons, and market UI sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899eec2bd408330b18b0e6bbaf6a288