### PR TITLE
Tune York flying island visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -4337,12 +4337,12 @@ function getFlyingIslandMetrics(islandEvent) {
   const x = islandEvent.container?.x ?? islandEvent.x ?? 0;
   const y = islandEvent.container?.y ?? islandEvent.y ?? 0;
   const greenCenterX = x;
-  const greenCenterY = y - 20;
-  const greenRadiusX = 76;
-  const greenRadiusY = 26;
-  const landingTopY = greenCenterY - 16;
-  const holeX = x + 24;
-  const holeY = y - 26;
+  const greenCenterY = y - 18;
+  const greenRadiusX = 114;
+  const greenRadiusY = 28;
+  const landingTopY = greenCenterY - 14;
+  const holeX = x + 30;
+  const holeY = y - 23;
   return {
     x,
     y,
@@ -4354,32 +4354,35 @@ function getFlyingIslandMetrics(islandEvent) {
     holeX,
     holeY,
     holeRadius: 12,
-    islandHalfWidth: 90,
-    islandHalfHeight: 64
+    islandHalfWidth: 136,
+    islandHalfHeight: 62
   };
 }
 
 function createFlyingIslandPlaceholder(scene) {
   const island = scene.add.container(0, 0).setDepth(23);
-  const shadow = scene.add.ellipse(0, 12, 154, 22, 0x000000, 0.18);
-  const underside = scene.add.ellipse(0, 18, 142, 86, 0x7a4a1f, 1);
-  const dirtTop = scene.add.ellipse(0, -6, 156, 54, 0x855629, 1);
-  const greenBase = scene.add.ellipse(0, -22, 158, 48, 0x27b857, 1);
-  const greenHighlight = scene.add.ellipse(-18, -28, 92, 20, 0x72f08c, 0.9);
-  const holeRim = scene.add.ellipse(24, -26, 24, 12, 0x143d22, 0.95);
-  const hole = scene.add.circle(24, -24, 8, 0x050505, 0.95);
-  const holeShade = scene.add.ellipse(24, -20, 18, 8, 0x000000, 0.3);
-  const rootLeft = scene.add.rectangle(-28, 44, 5, 20, 0x5a3315, 1).setAngle(-14);
-  const rootMid = scene.add.rectangle(2, 46, 4, 18, 0x5a3315, 1);
-  const rootRight = scene.add.rectangle(30, 44, 5, 22, 0x5a3315, 1).setAngle(14);
-  const rock1 = scene.add.circle(-44, 24, 12, 0x6b421b, 1);
-  const rock2 = scene.add.circle(0, 34, 11, 0x5f3918, 1);
-  const rock3 = scene.add.circle(40, 24, 10, 0x6e4520, 1);
-  const flagPole = scene.add.rectangle(44, -44, 4, 34, 0xe9e0c7, 1).setOrigin(0.5, 1);
-  const flag = scene.add.triangle(50, -70, 0, 0, 18, 8, 0, 16, 0xff4155, 1).setOrigin(0, 0.5);
-  const flagTip = scene.add.circle(44, -76, 3, 0xffe8a3, 1);
+  const shadow = scene.add.ellipse(0, 24, 220, 24, 0x000000, 0.16);
+  const underside = scene.add.ellipse(0, 18, 214, 64, 0x7a4a1f, 1);
+  const undersideFront = scene.add.rectangle(0, 28, 196, 34, 0x6b421b, 0.9).setStrokeStyle(3, 0x4b2910, 0.35);
+  const dirtLip = scene.add.ellipse(0, 0, 210, 36, 0x8a5a2b, 1);
+  const greenBase = scene.add.ellipse(0, -18, 236, 54, 0x27b857, 1);
+  const greenTrim = scene.add.ellipse(0, -10, 226, 20, 0x1d8f44, 0.55);
+  const greenHighlight = scene.add.ellipse(-34, -24, 126, 18, 0x72f08c, 0.82);
+  const holeRim = scene.add.ellipse(30, -22, 28, 12, 0x143d22, 0.95);
+  const hole = scene.add.circle(30, -20, 8, 0x050505, 0.95);
+  const holeShade = scene.add.ellipse(30, -16, 22, 8, 0x000000, 0.28);
+  const rootLeft = scene.add.rectangle(-56, 42, 7, 18, 0x5a3315, 1).setAngle(-6);
+  const rootMid = scene.add.rectangle(0, 44, 6, 16, 0x5a3315, 1);
+  const rootRight = scene.add.rectangle(54, 42, 7, 18, 0x5a3315, 1).setAngle(6);
+  const rock1 = scene.add.circle(-68, 26, 12, 0x6b421b, 1);
+  const rock2 = scene.add.circle(-14, 34, 10, 0x5f3918, 1);
+  const rock3 = scene.add.circle(40, 32, 11, 0x6e4520, 1);
+  const rock4 = scene.add.circle(80, 24, 10, 0x5b3516, 1);
+  const flagPole = scene.add.rectangle(72, -38, 4, 51, 0xe9e0c7, 1).setOrigin(0.5, 1);
+  const flag = scene.add.triangle(78, -79, 0, 0, 21, 9, 0, 18, 0xff4155, 1).setOrigin(0, 0.5);
+  const flagTip = scene.add.circle(72, -91, 3, 0xffe8a3, 1);
   const flagGroup = scene.add.container(0, 0, [flagPole, flag, flagTip]);
-  island.add([shadow, underside, dirtTop, greenBase, greenHighlight, holeRim, holeShade, hole, rootLeft, rootMid, rootRight, rock1, rock2, rock3, flagGroup]);
+  island.add([shadow, underside, undersideFront, dirtLip, greenBase, greenTrim, greenHighlight, holeRim, holeShade, hole, rootLeft, rootMid, rootRight, rock1, rock2, rock3, rock4, flagGroup]);
   island.flagGroup = flagGroup;
   island.flagPole = flagPole;
   island.flag = flag;


### PR DESCRIPTION
### Motivation
- Make the York flying island read more two-dimensional and less isometric while keeping existing gameplay unchanged.
- Increase the island footprint and the flag height so the visual target reads clearer and more like a side-on arcade platform.

### Description
- Flattened the placeholder silhouette inside `createFlyingIslandPlaceholder` by replacing stacked/isometric cues with a wider, shallower grassy cap (`greenBase`, `greenTrim`, `greenHighlight`), a chunky front-facing underside band (`undersideFront` / `dirtLip`) and a broader, lower shadow so the top reads front-on and the underside reads like a platform rather than a tilted mound.
- Widened the visible island shapes (larger `shadow`, `underside`, `greenBase`) and spread roots/rocks horizontally so perspective cues are reduced and the island reads flatter.
- Increased the island footprint metrics in `getFlyingIslandMetrics` so collision/detection match the new art: `greenRadiusX` from `76` → `114`, `greenRadiusY` from `26` → `28`, `greenCenterY` from `y - 20` → `y - 18`, `landingTopY` from `-16` → `-14`, `holeX` from `x + 24` → `x + 30`, `holeY` from `y - 26` → `y - 23`, and `islandHalfWidth` from `90` → `136` (island half height adjusted to `62`).
- Made the flag taller by increasing the pole height (`flagPole` height from `34` → `51`), moved the flag triangle and topper upward (flag coordinates adjusted), and left the existing success tween that targets `islandEvent.container.flagGroup` unchanged so the Mario-style drop animation continues to operate with the taller pole.
- All changes are limited to the York flying island placeholder helper and `getFlyingIslandMetrics`, so bounce behavior, hole sink detection, flag drop, fireworks, timing and other York events remain functionally the same but use the updated metrics.

### Testing
- Ran an inline JavaScript syntax check on the embedded `index.html` script using `node` which succeeded (`Inline script syntax OK`).
- Ran `git diff --check` to validate no whitespace/merge issues which passed.
- Verified that island landing, bounce and hole-detection code continue to derive geometry from `getFlyingIslandMetrics` so gameplay behaviors remain driven by the updated metrics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be6521ef408330b794536d64c9e78e)